### PR TITLE
feat: add core CRM API commands

### DIFF
--- a/api/crm.go
+++ b/api/crm.go
@@ -1,0 +1,256 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// ObjectType represents a HubSpot CRM object type
+type ObjectType string
+
+// Standard CRM object types
+const (
+	ObjectTypeContacts  ObjectType = "contacts"
+	ObjectTypeCompanies ObjectType = "companies"
+	ObjectTypeDeals     ObjectType = "deals"
+	ObjectTypeTickets   ObjectType = "tickets"
+	ObjectTypeProducts  ObjectType = "products"
+	ObjectTypeLineItems ObjectType = "line_items"
+	ObjectTypeQuotes    ObjectType = "quotes"
+	ObjectTypeNotes     ObjectType = "notes"
+	ObjectTypeCalls     ObjectType = "calls"
+	ObjectTypeEmails    ObjectType = "emails"
+	ObjectTypeMeetings  ObjectType = "meetings"
+	ObjectTypeTasks     ObjectType = "tasks"
+)
+
+// CRMObject represents a generic HubSpot CRM object
+type CRMObject struct {
+	ID         string                 `json:"id"`
+	Properties map[string]interface{} `json:"properties"`
+	CreatedAt  string                 `json:"createdAt"`
+	UpdatedAt  string                 `json:"updatedAt"`
+	Archived   bool                   `json:"archived,omitempty"`
+}
+
+// GetProperty returns a property value as a string, or empty string if not found
+func (o *CRMObject) GetProperty(name string) string {
+	if o.Properties == nil {
+		return ""
+	}
+	if v, ok := o.Properties[name]; ok {
+		if v == nil {
+			return ""
+		}
+		switch val := v.(type) {
+		case string:
+			return val
+		case float64:
+			return strconv.FormatFloat(val, 'f', -1, 64)
+		case bool:
+			return strconv.FormatBool(val)
+		default:
+			return fmt.Sprintf("%v", val)
+		}
+	}
+	return ""
+}
+
+// CRMObjectList represents a paginated list of CRM objects
+type CRMObjectList struct {
+	Results []CRMObject `json:"results"`
+	Paging  *Paging     `json:"paging,omitempty"`
+}
+
+// ListOptions contains common options for list operations
+type ListOptions struct {
+	Limit      int
+	After      string
+	Properties []string
+}
+
+// SearchFilter represents a single filter condition
+type SearchFilter struct {
+	PropertyName string `json:"propertyName"`
+	Operator     string `json:"operator"`
+	Value        string `json:"value,omitempty"`
+}
+
+// SearchFilterGroup represents a group of filters (ANDed together)
+type SearchFilterGroup struct {
+	Filters []SearchFilter `json:"filters"`
+}
+
+// SearchSort represents a sort condition
+type SearchSort struct {
+	PropertyName string `json:"propertyName"`
+	Direction    string `json:"direction"` // "ASCENDING" or "DESCENDING"
+}
+
+// SearchRequest represents a CRM search request
+type SearchRequest struct {
+	FilterGroups []SearchFilterGroup `json:"filterGroups,omitempty"`
+	Sorts        []SearchSort        `json:"sorts,omitempty"`
+	Properties   []string            `json:"properties,omitempty"`
+	Limit        int                 `json:"limit,omitempty"`
+	After        string              `json:"after,omitempty"`
+}
+
+// CreateRequest represents a CRM object creation request
+type CreateRequest struct {
+	Properties map[string]interface{} `json:"properties"`
+}
+
+// UpdateRequest represents a CRM object update request
+type UpdateRequest struct {
+	Properties map[string]interface{} `json:"properties"`
+}
+
+// ListObjects lists CRM objects of the given type
+func (c *Client) ListObjects(objectType ObjectType, opts ListOptions) (*CRMObjectList, error) {
+	url := fmt.Sprintf("%s/crm/v3/objects/%s", c.BaseURL, objectType)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+	if len(opts.Properties) > 0 {
+		// HubSpot accepts comma-separated properties
+		props := ""
+		for i, p := range opts.Properties {
+			if i > 0 {
+				props += ","
+			}
+			props += p
+		}
+		params["properties"] = props
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result CRMObjectList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetObject retrieves a single CRM object by ID
+func (c *Client) GetObject(objectType ObjectType, id string, properties []string) (*CRMObject, error) {
+	if id == "" {
+		return nil, fmt.Errorf("object ID is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v3/objects/%s/%s", c.BaseURL, objectType, id)
+
+	params := make(map[string]string)
+	if len(properties) > 0 {
+		props := ""
+		for i, p := range properties {
+			if i > 0 {
+				props += ","
+			}
+			props += p
+		}
+		params["properties"] = props
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result CRMObject
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CreateObject creates a new CRM object
+func (c *Client) CreateObject(objectType ObjectType, properties map[string]interface{}) (*CRMObject, error) {
+	url := fmt.Sprintf("%s/crm/v3/objects/%s", c.BaseURL, objectType)
+
+	req := CreateRequest{Properties: properties}
+
+	body, err := c.post(url, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result CRMObject
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// UpdateObject updates an existing CRM object
+func (c *Client) UpdateObject(objectType ObjectType, id string, properties map[string]interface{}) (*CRMObject, error) {
+	if id == "" {
+		return nil, fmt.Errorf("object ID is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v3/objects/%s/%s", c.BaseURL, objectType, id)
+
+	req := UpdateRequest{Properties: properties}
+
+	body, err := c.patch(url, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result CRMObject
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteObject deletes a CRM object (moves to archive)
+func (c *Client) DeleteObject(objectType ObjectType, id string) error {
+	if id == "" {
+		return fmt.Errorf("object ID is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v3/objects/%s/%s", c.BaseURL, objectType, id)
+
+	_, err := c.delete(url)
+	return err
+}
+
+// SearchObjects searches for CRM objects
+func (c *Client) SearchObjects(objectType ObjectType, req SearchRequest) (*CRMObjectList, error) {
+	url := fmt.Sprintf("%s/crm/v3/objects/%s/search", c.BaseURL, objectType)
+
+	body, err := c.post(url, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result CRMObjectList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/api/crm_test.go
+++ b/api/crm_test.go
@@ -1,0 +1,469 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCRMObject_GetProperty(t *testing.T) {
+	tests := []struct {
+		name       string
+		properties map[string]interface{}
+		propName   string
+		want       string
+	}{
+		{
+			name: "string property",
+			properties: map[string]interface{}{
+				"email": "john@example.com",
+			},
+			propName: "email",
+			want:     "john@example.com",
+		},
+		{
+			name: "number property",
+			properties: map[string]interface{}{
+				"amount": float64(1234.56),
+			},
+			propName: "amount",
+			want:     "1234.56",
+		},
+		{
+			name: "integer as float",
+			properties: map[string]interface{}{
+				"count": float64(42),
+			},
+			propName: "count",
+			want:     "42",
+		},
+		{
+			name: "bool property",
+			properties: map[string]interface{}{
+				"active": true,
+			},
+			propName: "active",
+			want:     "true",
+		},
+		{
+			name: "nil property",
+			properties: map[string]interface{}{
+				"email": nil,
+			},
+			propName: "email",
+			want:     "",
+		},
+		{
+			name: "missing property",
+			properties: map[string]interface{}{
+				"email": "test@example.com",
+			},
+			propName: "phone",
+			want:     "",
+		},
+		{
+			name:       "nil properties map",
+			properties: nil,
+			propName:   "email",
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &CRMObject{Properties: tt.properties}
+			got := obj.GetProperty(tt.propName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClient_ListObjects(t *testing.T) {
+	t.Run("list contacts", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/crm/v3/objects/contacts", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "10", r.URL.Query().Get("limit"))
+			assert.Equal(t, "email,firstname,lastname", r.URL.Query().Get("properties"))
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "123",
+						"properties": {
+							"email": "john@example.com",
+							"firstname": "John",
+							"lastname": "Doe"
+						},
+						"createdAt": "2024-01-15T10:00:00Z",
+						"updatedAt": "2024-01-15T10:00:00Z"
+					}
+				],
+				"paging": {
+					"next": {
+						"after": "abc123"
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListObjects(ObjectTypeContacts, ListOptions{
+			Limit:      10,
+			Properties: []string{"email", "firstname", "lastname"},
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "123", result.Results[0].ID)
+		assert.Equal(t, "john@example.com", result.Results[0].GetProperty("email"))
+		assert.Equal(t, "abc123", result.Paging.Next.After)
+	})
+
+	t.Run("with pagination cursor", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "cursor123", r.URL.Query().Get("after"))
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		_, err := client.ListObjects(ObjectTypeContacts, ListOptions{After: "cursor123"})
+		require.NoError(t, err)
+	})
+}
+
+func TestClient_GetObject(t *testing.T) {
+	t.Run("get contact by ID", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/crm/v3/objects/contacts/12345", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"properties": {
+					"email": "jane@example.com",
+					"firstname": "Jane",
+					"lastname": "Smith"
+				},
+				"createdAt": "2024-01-15T10:00:00Z",
+				"updatedAt": "2024-01-16T12:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		obj, err := client.GetObject(ObjectTypeContacts, "12345", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "12345", obj.ID)
+		assert.Equal(t, "jane@example.com", obj.GetProperty("email"))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Contact not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		obj, err := client.GetObject(ObjectTypeContacts, "99999", nil)
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, obj)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		obj, err := client.GetObject(ObjectTypeContacts, "", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "object ID is required")
+		assert.Nil(t, obj)
+	})
+}
+
+func TestClient_CreateObject(t *testing.T) {
+	t.Run("create contact", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/crm/v3/objects/contacts", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{
+				"id": "67890",
+				"properties": {
+					"email": "new@example.com",
+					"firstname": "New",
+					"lastname": "Contact"
+				},
+				"createdAt": "2024-01-20T10:00:00Z",
+				"updatedAt": "2024-01-20T10:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		obj, err := client.CreateObject(ObjectTypeContacts, map[string]interface{}{
+			"email":     "new@example.com",
+			"firstname": "New",
+			"lastname":  "Contact",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "67890", obj.ID)
+		assert.Equal(t, "new@example.com", obj.GetProperty("email"))
+	})
+
+	t.Run("bad request - missing required field", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"status": "error", "message": "Property 'email' is required"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		obj, err := client.CreateObject(ObjectTypeContacts, map[string]interface{}{
+			"firstname": "No Email",
+		})
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "email")
+		assert.Nil(t, obj)
+	})
+}
+
+func TestClient_UpdateObject(t *testing.T) {
+	t.Run("update contact", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/crm/v3/objects/contacts/12345", r.URL.Path)
+			assert.Equal(t, http.MethodPatch, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "12345",
+				"properties": {
+					"email": "john@example.com",
+					"firstname": "Johnny",
+					"lastname": "Doe"
+				},
+				"createdAt": "2024-01-15T10:00:00Z",
+				"updatedAt": "2024-01-20T10:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		obj, err := client.UpdateObject(ObjectTypeContacts, "12345", map[string]interface{}{
+			"firstname": "Johnny",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "12345", obj.ID)
+		assert.Equal(t, "Johnny", obj.GetProperty("firstname"))
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		obj, err := client.UpdateObject(ObjectTypeContacts, "", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "object ID is required")
+		assert.Nil(t, obj)
+	})
+}
+
+func TestClient_DeleteObject(t *testing.T) {
+	t.Run("delete contact", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/crm/v3/objects/contacts/12345", r.URL.Path)
+			assert.Equal(t, http.MethodDelete, r.Method)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		err := client.DeleteObject(ObjectTypeContacts, "12345")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Contact not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		err := client.DeleteObject(ObjectTypeContacts, "99999")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		err := client.DeleteObject(ObjectTypeContacts, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "object ID is required")
+	})
+}
+
+func TestClient_SearchObjects(t *testing.T) {
+	t.Run("search contacts by email", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/crm/v3/objects/contacts/search", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "123",
+						"properties": {
+							"email": "john@example.com",
+							"firstname": "John"
+						}
+					}
+				],
+				"total": 1
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.SearchObjects(ObjectTypeContacts, SearchRequest{
+			FilterGroups: []SearchFilterGroup{
+				{
+					Filters: []SearchFilter{
+						{
+							PropertyName: "email",
+							Operator:     "EQ",
+							Value:        "john@example.com",
+						},
+					},
+				},
+			},
+			Properties: []string{"email", "firstname"},
+			Limit:      10,
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "123", result.Results[0].ID)
+	})
+
+	t.Run("search with sort", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		_, err := client.SearchObjects(ObjectTypeContacts, SearchRequest{
+			Sorts: []SearchSort{
+				{PropertyName: "createdate", Direction: "DESCENDING"},
+			},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func TestClient_AllObjectTypes(t *testing.T) {
+	// Verify all object types work with the generic methods
+	objectTypes := []ObjectType{
+		ObjectTypeContacts,
+		ObjectTypeCompanies,
+		ObjectTypeDeals,
+		ObjectTypeTickets,
+		ObjectTypeProducts,
+		ObjectTypeLineItems,
+		ObjectTypeQuotes,
+		ObjectTypeNotes,
+		ObjectTypeCalls,
+		ObjectTypeEmails,
+		ObjectTypeMeetings,
+		ObjectTypeTasks,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	client := &Client{
+		BaseURL:     server.URL,
+		AccessToken: "test-token",
+		HTTPClient:  server.Client(),
+	}
+
+	for _, ot := range objectTypes {
+		t.Run(string(ot), func(t *testing.T) {
+			result, err := client.ListObjects(ot, ListOptions{Limit: 1})
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+		})
+	}
+}

--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -4,10 +4,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/companies"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/completion"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/configcmd"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/contacts"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/deals"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/initcmd"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/owners"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/tickets"
 	"github.com/open-cli-collective/hubspot-cli/internal/exitcode"
 )
 
@@ -25,6 +30,13 @@ func run() error {
 	initcmd.Register(rootCmd, opts)
 	configcmd.Register(rootCmd, opts)
 	completion.Register(rootCmd, opts)
+
+	// CRM commands
+	contacts.Register(rootCmd, opts)
+	companies.Register(rootCmd, opts)
+	deals.Register(rootCmd, opts)
+	tickets.Register(rootCmd, opts)
+	owners.Register(rootCmd, opts)
 
 	return rootCmd.Execute()
 }

--- a/internal/cmd/companies/companies.go
+++ b/internal/cmd/companies/companies.go
@@ -1,0 +1,437 @@
+package companies
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for companies
+var DefaultProperties = []string{"name", "domain", "industry", "phone", "city", "state", "country"}
+
+// Register registers the companies command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "companies",
+		Short: "Manage HubSpot companies",
+		Long:  "Commands for listing, viewing, creating, updating, and searching companies in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+	cmd.AddCommand(newSearchCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List companies",
+		Long:  "List companies from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 companies
+  hspt companies list
+
+  # List with custom properties
+  hspt companies list --properties name,domain,industry
+
+  # List with pagination
+  hspt companies list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeCompanies, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No companies found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "DOMAIN", "INDUSTRY", "CITY"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("name"),
+					obj.GetProperty("domain"),
+					obj.GetProperty("industry"),
+					obj.GetProperty("city"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of companies to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a company by ID",
+		Long:  "Retrieve a single company by its ID from HubSpot CRM.",
+		Example: `  # Get company by ID
+  hspt companies get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeCompanies, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Company %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Name", obj.GetProperty("name")},
+				{"Domain", obj.GetProperty("domain")},
+				{"Industry", obj.GetProperty("industry")},
+				{"Phone", obj.GetProperty("phone")},
+				{"City", obj.GetProperty("city")},
+				{"State", obj.GetProperty("state")},
+				{"Country", obj.GetProperty("country")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var name, domain, industry, phone, city string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new company",
+		Long:  "Create a new company in HubSpot CRM.",
+		Example: `  # Create with common fields
+  hspt companies create --name "Acme Inc" --domain acme.com
+
+  # Create with custom properties
+  hspt companies create --name "Acme Inc" --prop numberofemployees=100`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if name != "" {
+				properties["name"] = name
+			}
+			if domain != "" {
+				properties["domain"] = domain
+			}
+			if industry != "" {
+				properties["industry"] = industry
+			}
+			if phone != "" {
+				properties["phone"] = phone
+			}
+			if city != "" {
+				properties["city"] = city
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeCompanies, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Company created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Name", obj.GetProperty("name")},
+				{"Domain", obj.GetProperty("domain")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Company name")
+	cmd.Flags().StringVar(&domain, "domain", "", "Company domain")
+	cmd.Flags().StringVar(&industry, "industry", "", "Industry")
+	cmd.Flags().StringVar(&phone, "phone", "", "Phone number")
+	cmd.Flags().StringVar(&city, "city", "", "City")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var name, domain, industry, phone, city string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a company",
+		Long:  "Update an existing company in HubSpot CRM.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if name != "" {
+				properties["name"] = name
+			}
+			if domain != "" {
+				properties["domain"] = domain
+			}
+			if industry != "" {
+				properties["industry"] = industry
+			}
+			if phone != "" {
+				properties["phone"] = phone
+			}
+			if city != "" {
+				properties["city"] = city
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeCompanies, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Company %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Company %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Company name")
+	cmd.Flags().StringVar(&domain, "domain", "", "Company domain")
+	cmd.Flags().StringVar(&industry, "industry", "", "Industry")
+	cmd.Flags().StringVar(&phone, "phone", "", "Phone number")
+	cmd.Flags().StringVar(&city, "city", "", "City")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a company",
+		Long:  "Archive (soft delete) a company in HubSpot CRM.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive company %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeCompanies, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Company %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Company %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func newSearchCmd(opts *root.Options) *cobra.Command {
+	var name, domain string
+	var limit int
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search companies",
+		Long:  "Search for companies using filters.",
+		Example: `  # Search by domain
+  hspt companies search --domain acme.com
+
+  # Search by name
+  hspt companies search --name "Acme"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			var filters []api.SearchFilter
+
+			if name != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "name",
+					Operator:     "CONTAINS_TOKEN",
+					Value:        name,
+				})
+			}
+			if domain != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "domain",
+					Operator:     "EQ",
+					Value:        domain,
+				})
+			}
+
+			req := api.SearchRequest{
+				Properties: properties,
+				Limit:      limit,
+			}
+
+			if len(filters) > 0 {
+				req.FilterGroups = []api.SearchFilterGroup{
+					{Filters: filters},
+				}
+			}
+
+			result, err := client.SearchObjects(api.ObjectTypeCompanies, req)
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No companies found matching criteria")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "DOMAIN", "INDUSTRY", "CITY"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("name"),
+					obj.GetProperty("domain"),
+					obj.GetProperty("industry"),
+					obj.GetProperty("city"),
+				})
+			}
+
+			v.Info("Found %d company(ies)", len(result.Results))
+			return v.Render(headers, rows, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Search by name (contains)")
+	cmd.Flags().StringVar(&domain, "domain", "", "Search by exact domain")
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of results")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}

--- a/internal/cmd/contacts/contacts.go
+++ b/internal/cmd/contacts/contacts.go
@@ -1,0 +1,484 @@
+package contacts
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for contacts
+var DefaultProperties = []string{"email", "firstname", "lastname", "phone", "company"}
+
+// Register registers the contacts command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "contacts",
+		Short: "Manage HubSpot contacts",
+		Long:  "Commands for listing, viewing, creating, updating, and searching contacts in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+	cmd.AddCommand(newSearchCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List contacts",
+		Long:  "List contacts from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 contacts
+  hspt contacts list
+
+  # List with custom properties
+  hspt contacts list --properties email,firstname,lastname,company
+
+  # List with pagination
+  hspt contacts list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeContacts, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No contacts found")
+				return nil
+			}
+
+			headers := []string{"ID", "EMAIL", "FIRST NAME", "LAST NAME", "PHONE", "COMPANY"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("email"),
+					obj.GetProperty("firstname"),
+					obj.GetProperty("lastname"),
+					obj.GetProperty("phone"),
+					obj.GetProperty("company"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of contacts to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a contact by ID",
+		Long:  "Retrieve a single contact by its ID from HubSpot CRM.",
+		Example: `  # Get contact by ID
+  hspt contacts get 12345
+
+  # Get with specific properties
+  hspt contacts get 12345 --properties email,firstname,lastname`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeContacts, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Contact %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Email", obj.GetProperty("email")},
+				{"First Name", obj.GetProperty("firstname")},
+				{"Last Name", obj.GetProperty("lastname")},
+				{"Phone", obj.GetProperty("phone")},
+				{"Company", obj.GetProperty("company")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var email, firstname, lastname, phone, company string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new contact",
+		Long:  "Create a new contact in HubSpot CRM.",
+		Example: `  # Create with common fields
+  hspt contacts create --email john@example.com --firstname John --lastname Doe
+
+  # Create with custom properties
+  hspt contacts create --email john@example.com --prop lifecyclestage=customer`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if email != "" {
+				properties["email"] = email
+			}
+			if firstname != "" {
+				properties["firstname"] = firstname
+			}
+			if lastname != "" {
+				properties["lastname"] = lastname
+			}
+			if phone != "" {
+				properties["phone"] = phone
+			}
+			if company != "" {
+				properties["company"] = company
+			}
+
+			// Parse custom properties
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeContacts, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Contact created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Email", obj.GetProperty("email")},
+				{"First Name", obj.GetProperty("firstname")},
+				{"Last Name", obj.GetProperty("lastname")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Contact email address")
+	cmd.Flags().StringVar(&firstname, "firstname", "", "Contact first name")
+	cmd.Flags().StringVar(&lastname, "lastname", "", "Contact last name")
+	cmd.Flags().StringVar(&phone, "phone", "", "Contact phone number")
+	cmd.Flags().StringVar(&company, "company", "", "Contact company name")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var email, firstname, lastname, phone, company string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a contact",
+		Long:  "Update an existing contact in HubSpot CRM.",
+		Example: `  # Update contact name
+  hspt contacts update 12345 --firstname Johnny
+
+  # Update custom property
+  hspt contacts update 12345 --prop lifecyclestage=customer`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if email != "" {
+				properties["email"] = email
+			}
+			if firstname != "" {
+				properties["firstname"] = firstname
+			}
+			if lastname != "" {
+				properties["lastname"] = lastname
+			}
+			if phone != "" {
+				properties["phone"] = phone
+			}
+			if company != "" {
+				properties["company"] = company
+			}
+
+			// Parse custom properties
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeContacts, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Contact %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Contact %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Contact email address")
+	cmd.Flags().StringVar(&firstname, "firstname", "", "Contact first name")
+	cmd.Flags().StringVar(&lastname, "lastname", "", "Contact last name")
+	cmd.Flags().StringVar(&phone, "phone", "", "Contact phone number")
+	cmd.Flags().StringVar(&company, "company", "", "Contact company name")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a contact",
+		Long:  "Archive (soft delete) a contact in HubSpot CRM.",
+		Example: `  # Delete contact
+  hspt contacts delete 12345
+
+  # Delete without confirmation
+  hspt contacts delete 12345 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive contact %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeContacts, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Contact %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Contact %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func newSearchCmd(opts *root.Options) *cobra.Command {
+	var email, firstname, lastname string
+	var query string
+	var limit int
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search contacts",
+		Long:  "Search for contacts using filters.",
+		Example: `  # Search by email
+  hspt contacts search --email john@example.com
+
+  # Search by name
+  hspt contacts search --firstname John --lastname Doe
+
+  # Full-text search
+  hspt contacts search --query "john"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			// Build filters
+			var filters []api.SearchFilter
+
+			if email != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "email",
+					Operator:     "EQ",
+					Value:        email,
+				})
+			}
+			if firstname != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "firstname",
+					Operator:     "CONTAINS_TOKEN",
+					Value:        firstname,
+				})
+			}
+			if lastname != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "lastname",
+					Operator:     "CONTAINS_TOKEN",
+					Value:        lastname,
+				})
+			}
+
+			req := api.SearchRequest{
+				Properties: properties,
+				Limit:      limit,
+			}
+
+			if len(filters) > 0 {
+				req.FilterGroups = []api.SearchFilterGroup{
+					{Filters: filters},
+				}
+			}
+
+			// Note: HubSpot search API doesn't have a direct full-text query parameter
+			// for contacts like some other APIs. The filters above handle specific field searches.
+			if query != "" && len(filters) == 0 {
+				// For simple query, search in email field
+				req.FilterGroups = []api.SearchFilterGroup{
+					{
+						Filters: []api.SearchFilter{
+							{
+								PropertyName: "email",
+								Operator:     "CONTAINS_TOKEN",
+								Value:        query,
+							},
+						},
+					},
+				}
+			}
+
+			result, err := client.SearchObjects(api.ObjectTypeContacts, req)
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No contacts found matching criteria")
+				return nil
+			}
+
+			headers := []string{"ID", "EMAIL", "FIRST NAME", "LAST NAME", "PHONE", "COMPANY"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("email"),
+					obj.GetProperty("firstname"),
+					obj.GetProperty("lastname"),
+					obj.GetProperty("phone"),
+					obj.GetProperty("company"),
+				})
+			}
+
+			v.Info("Found %d contact(s)", len(result.Results))
+			return v.Render(headers, rows, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Search by exact email")
+	cmd.Flags().StringVar(&firstname, "firstname", "", "Search by first name (contains)")
+	cmd.Flags().StringVar(&lastname, "lastname", "", "Search by last name (contains)")
+	cmd.Flags().StringVar(&query, "query", "", "Full-text search query")
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of results")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}

--- a/internal/cmd/deals/deals.go
+++ b/internal/cmd/deals/deals.go
@@ -1,0 +1,455 @@
+package deals
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for deals
+var DefaultProperties = []string{"dealname", "amount", "dealstage", "pipeline", "closedate", "hubspot_owner_id"}
+
+// Register registers the deals command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "deals",
+		Short: "Manage HubSpot deals",
+		Long:  "Commands for listing, viewing, creating, updating, and searching deals in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+	cmd.AddCommand(newSearchCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List deals",
+		Long:  "List deals from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 deals
+  hspt deals list
+
+  # List with custom properties
+  hspt deals list --properties dealname,amount,dealstage
+
+  # List with pagination
+  hspt deals list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeDeals, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No deals found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "AMOUNT", "STAGE", "PIPELINE", "CLOSE DATE"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("dealname"),
+					obj.GetProperty("amount"),
+					obj.GetProperty("dealstage"),
+					obj.GetProperty("pipeline"),
+					obj.GetProperty("closedate"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of deals to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a deal by ID",
+		Long:  "Retrieve a single deal by its ID from HubSpot CRM.",
+		Example: `  # Get deal by ID
+  hspt deals get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeDeals, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Deal %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Name", obj.GetProperty("dealname")},
+				{"Amount", obj.GetProperty("amount")},
+				{"Stage", obj.GetProperty("dealstage")},
+				{"Pipeline", obj.GetProperty("pipeline")},
+				{"Close Date", obj.GetProperty("closedate")},
+				{"Owner ID", obj.GetProperty("hubspot_owner_id")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var dealname, amount, dealstage, pipeline, closedate, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new deal",
+		Long:  "Create a new deal in HubSpot CRM.",
+		Example: `  # Create with common fields
+  hspt deals create --name "New Enterprise Deal" --amount 50000 --stage qualifiedtobuy
+
+  # Create with pipeline and close date
+  hspt deals create --name "Q1 Deal" --pipeline default --closedate 2024-03-31`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if dealname != "" {
+				properties["dealname"] = dealname
+			}
+			if amount != "" {
+				properties["amount"] = amount
+			}
+			if dealstage != "" {
+				properties["dealstage"] = dealstage
+			}
+			if pipeline != "" {
+				properties["pipeline"] = pipeline
+			}
+			if closedate != "" {
+				properties["closedate"] = closedate
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeDeals, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Deal created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Name", obj.GetProperty("dealname")},
+				{"Amount", obj.GetProperty("amount")},
+				{"Stage", obj.GetProperty("dealstage")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&dealname, "name", "", "Deal name")
+	cmd.Flags().StringVar(&amount, "amount", "", "Deal amount")
+	cmd.Flags().StringVar(&dealstage, "stage", "", "Deal stage")
+	cmd.Flags().StringVar(&pipeline, "pipeline", "", "Pipeline ID")
+	cmd.Flags().StringVar(&closedate, "closedate", "", "Close date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&ownerID, "owner", "", "Owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var dealname, amount, dealstage, pipeline, closedate, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a deal",
+		Long:  "Update an existing deal in HubSpot CRM.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if dealname != "" {
+				properties["dealname"] = dealname
+			}
+			if amount != "" {
+				properties["amount"] = amount
+			}
+			if dealstage != "" {
+				properties["dealstage"] = dealstage
+			}
+			if pipeline != "" {
+				properties["pipeline"] = pipeline
+			}
+			if closedate != "" {
+				properties["closedate"] = closedate
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeDeals, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Deal %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Deal %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&dealname, "name", "", "Deal name")
+	cmd.Flags().StringVar(&amount, "amount", "", "Deal amount")
+	cmd.Flags().StringVar(&dealstage, "stage", "", "Deal stage")
+	cmd.Flags().StringVar(&pipeline, "pipeline", "", "Pipeline ID")
+	cmd.Flags().StringVar(&closedate, "closedate", "", "Close date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&ownerID, "owner", "", "Owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a deal",
+		Long:  "Archive (soft delete) a deal in HubSpot CRM.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive deal %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeDeals, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Deal %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Deal %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func newSearchCmd(opts *root.Options) *cobra.Command {
+	var dealname, dealstage, pipeline string
+	var limit int
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search deals",
+		Long:  "Search for deals using filters.",
+		Example: `  # Search by name
+  hspt deals search --name "Enterprise"
+
+  # Search by stage
+  hspt deals search --stage closedwon`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			var filters []api.SearchFilter
+
+			if dealname != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "dealname",
+					Operator:     "CONTAINS_TOKEN",
+					Value:        dealname,
+				})
+			}
+			if dealstage != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "dealstage",
+					Operator:     "EQ",
+					Value:        dealstage,
+				})
+			}
+			if pipeline != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "pipeline",
+					Operator:     "EQ",
+					Value:        pipeline,
+				})
+			}
+
+			req := api.SearchRequest{
+				Properties: properties,
+				Limit:      limit,
+			}
+
+			if len(filters) > 0 {
+				req.FilterGroups = []api.SearchFilterGroup{
+					{Filters: filters},
+				}
+			}
+
+			result, err := client.SearchObjects(api.ObjectTypeDeals, req)
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No deals found matching criteria")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "AMOUNT", "STAGE", "PIPELINE", "CLOSE DATE"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("dealname"),
+					obj.GetProperty("amount"),
+					obj.GetProperty("dealstage"),
+					obj.GetProperty("pipeline"),
+					obj.GetProperty("closedate"),
+				})
+			}
+
+			v.Info("Found %d deal(s)", len(result.Results))
+			return v.Render(headers, rows, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&dealname, "name", "", "Search by name (contains)")
+	cmd.Flags().StringVar(&dealstage, "stage", "", "Search by exact deal stage")
+	cmd.Flags().StringVar(&pipeline, "pipeline", "", "Search by pipeline ID")
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of results")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}

--- a/internal/cmd/owners/owners.go
+++ b/internal/cmd/owners/owners.go
@@ -1,0 +1,125 @@
+package owners
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the owners command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "owners",
+		Short: "Manage HubSpot owners",
+		Long:  "Commands for listing and viewing owners (users) in HubSpot.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List owners",
+		Long:  "List all owners (users) in HubSpot.",
+		Example: `  # List all owners
+  hspt owners list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			owners, err := client.GetOwners()
+			if err != nil {
+				return err
+			}
+
+			if len(owners) == 0 {
+				v.Info("No owners found")
+				return nil
+			}
+
+			headers := []string{"ID", "EMAIL", "NAME", "ARCHIVED"}
+			rows := make([][]string, 0, len(owners))
+			for _, owner := range owners {
+				archived := "No"
+				if owner.Archived {
+					archived = "Yes"
+				}
+				rows = append(rows, []string{
+					owner.ID,
+					owner.Email,
+					owner.FullName(),
+					archived,
+				})
+			}
+
+			return v.Render(headers, rows, owners)
+		},
+	}
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get an owner by ID",
+		Long:  "Retrieve a single owner by their ID.",
+		Example: `  # Get owner by ID
+  hspt owners get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			owner, err := client.GetOwner(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Owner %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", owner.ID},
+				{"Email", owner.Email},
+				{"Name", owner.FullName()},
+				{"First Name", owner.FirstName},
+				{"Last Name", owner.LastName},
+				{"Archived", formatBool(owner.Archived)},
+			}
+
+			if len(owner.Teams) > 0 {
+				for _, team := range owner.Teams {
+					primary := ""
+					if team.Primary {
+						primary = " (primary)"
+					}
+					rows = append(rows, []string{"Team", team.Name + primary})
+				}
+			}
+
+			return v.Render(headers, rows, owner)
+		},
+	}
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}

--- a/internal/cmd/tickets/tickets.go
+++ b/internal/cmd/tickets/tickets.go
@@ -1,0 +1,461 @@
+package tickets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for tickets
+var DefaultProperties = []string{"subject", "content", "hs_pipeline", "hs_pipeline_stage", "hs_ticket_priority", "hubspot_owner_id"}
+
+// Register registers the tickets command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "tickets",
+		Short: "Manage HubSpot tickets",
+		Long:  "Commands for listing, viewing, creating, updating, and searching tickets in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+	cmd.AddCommand(newSearchCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tickets",
+		Long:  "List tickets from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 tickets
+  hspt tickets list
+
+  # List with custom properties
+  hspt tickets list --properties subject,hs_pipeline_stage,hs_ticket_priority
+
+  # List with pagination
+  hspt tickets list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeTickets, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No tickets found")
+				return nil
+			}
+
+			headers := []string{"ID", "SUBJECT", "STAGE", "PRIORITY", "PIPELINE"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("subject"),
+					obj.GetProperty("hs_pipeline_stage"),
+					obj.GetProperty("hs_ticket_priority"),
+					obj.GetProperty("hs_pipeline"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of tickets to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a ticket by ID",
+		Long:  "Retrieve a single ticket by its ID from HubSpot CRM.",
+		Example: `  # Get ticket by ID
+  hspt tickets get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeTickets, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Ticket %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Subject", obj.GetProperty("subject")},
+				{"Content", obj.GetProperty("content")},
+				{"Pipeline", obj.GetProperty("hs_pipeline")},
+				{"Stage", obj.GetProperty("hs_pipeline_stage")},
+				{"Priority", obj.GetProperty("hs_ticket_priority")},
+				{"Owner ID", obj.GetProperty("hubspot_owner_id")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var subject, content, pipeline, stage, priority, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new ticket",
+		Long:  "Create a new ticket in HubSpot CRM.",
+		Example: `  # Create with common fields
+  hspt tickets create --subject "Login issue" --priority HIGH
+
+  # Create with content and pipeline
+  hspt tickets create --subject "Bug report" --content "Details here..." --pipeline 0`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if subject != "" {
+				properties["subject"] = subject
+			}
+			if content != "" {
+				properties["content"] = content
+			}
+			if pipeline != "" {
+				properties["hs_pipeline"] = pipeline
+			}
+			if stage != "" {
+				properties["hs_pipeline_stage"] = stage
+			}
+			if priority != "" {
+				properties["hs_ticket_priority"] = priority
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeTickets, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Ticket created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Subject", obj.GetProperty("subject")},
+				{"Stage", obj.GetProperty("hs_pipeline_stage")},
+				{"Priority", obj.GetProperty("hs_ticket_priority")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "Ticket subject")
+	cmd.Flags().StringVar(&content, "content", "", "Ticket content/description")
+	cmd.Flags().StringVar(&pipeline, "pipeline", "", "Pipeline ID")
+	cmd.Flags().StringVar(&stage, "stage", "", "Pipeline stage")
+	cmd.Flags().StringVar(&priority, "priority", "", "Priority (LOW, MEDIUM, HIGH)")
+	cmd.Flags().StringVar(&ownerID, "owner", "", "Owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var subject, content, pipeline, stage, priority, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a ticket",
+		Long:  "Update an existing ticket in HubSpot CRM.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if subject != "" {
+				properties["subject"] = subject
+			}
+			if content != "" {
+				properties["content"] = content
+			}
+			if pipeline != "" {
+				properties["hs_pipeline"] = pipeline
+			}
+			if stage != "" {
+				properties["hs_pipeline_stage"] = stage
+			}
+			if priority != "" {
+				properties["hs_ticket_priority"] = priority
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeTickets, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Ticket %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Ticket %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "Ticket subject")
+	cmd.Flags().StringVar(&content, "content", "", "Ticket content/description")
+	cmd.Flags().StringVar(&pipeline, "pipeline", "", "Pipeline ID")
+	cmd.Flags().StringVar(&stage, "stage", "", "Pipeline stage")
+	cmd.Flags().StringVar(&priority, "priority", "", "Priority (LOW, MEDIUM, HIGH)")
+	cmd.Flags().StringVar(&ownerID, "owner", "", "Owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a ticket",
+		Long:  "Archive (soft delete) a ticket in HubSpot CRM.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive ticket %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeTickets, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Ticket %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Ticket %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func newSearchCmd(opts *root.Options) *cobra.Command {
+	var subject, stage, priority, pipeline string
+	var limit int
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search tickets",
+		Long:  "Search for tickets using filters.",
+		Example: `  # Search by subject
+  hspt tickets search --subject "login"
+
+  # Search by priority
+  hspt tickets search --priority HIGH`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			var filters []api.SearchFilter
+
+			if subject != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "subject",
+					Operator:     "CONTAINS_TOKEN",
+					Value:        subject,
+				})
+			}
+			if stage != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "hs_pipeline_stage",
+					Operator:     "EQ",
+					Value:        stage,
+				})
+			}
+			if priority != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "hs_ticket_priority",
+					Operator:     "EQ",
+					Value:        priority,
+				})
+			}
+			if pipeline != "" {
+				filters = append(filters, api.SearchFilter{
+					PropertyName: "hs_pipeline",
+					Operator:     "EQ",
+					Value:        pipeline,
+				})
+			}
+
+			req := api.SearchRequest{
+				Properties: properties,
+				Limit:      limit,
+			}
+
+			if len(filters) > 0 {
+				req.FilterGroups = []api.SearchFilterGroup{
+					{Filters: filters},
+				}
+			}
+
+			result, err := client.SearchObjects(api.ObjectTypeTickets, req)
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No tickets found matching criteria")
+				return nil
+			}
+
+			headers := []string{"ID", "SUBJECT", "STAGE", "PRIORITY", "PIPELINE"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("subject"),
+					obj.GetProperty("hs_pipeline_stage"),
+					obj.GetProperty("hs_ticket_priority"),
+					obj.GetProperty("hs_pipeline"),
+				})
+			}
+
+			v.Info("Found %d ticket(s)", len(result.Results))
+			return v.Render(headers, rows, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "Search by subject (contains)")
+	cmd.Flags().StringVar(&stage, "stage", "", "Search by pipeline stage")
+	cmd.Flags().StringVar(&priority, "priority", "", "Search by priority (LOW, MEDIUM, HIGH)")
+	cmd.Flags().StringVar(&pipeline, "pipeline", "", "Search by pipeline ID")
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of results")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}


### PR DESCRIPTION
## Summary
- Add generic CRM API client in `api/crm.go` supporting all HubSpot object types
- Implement CLI commands for core CRM objects:
  - **contacts**: list, get, create, update, delete, search
  - **companies**: list, get, create, update, delete, search
  - **deals**: list, get, create, update, delete, search (with pipeline support)
  - **tickets**: list, get, create, update, delete, search (with pipeline support)
  - **owners**: list, get
- 40+ new tests for CRM API methods

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes
- [x] `hspt --help` shows new commands
- [x] `hspt contacts --help` shows subcommands

## Note
This is a partial implementation of #4. The remaining items (engagements, associations, properties, pipelines, custom objects) will be addressed in follow-up issues to keep this PR reviewable.

Closes #4