### PR TITLE
feat: add Marketing API commands (forms, campaigns)

### DIFF
--- a/api/marketing.go
+++ b/api/marketing.go
@@ -1,0 +1,200 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Form represents a HubSpot form
+type Form struct {
+	ID          string           `json:"id"`
+	Name        string           `json:"name"`
+	FormType    string           `json:"formType"`
+	CreatedAt   string           `json:"createdAt"`
+	UpdatedAt   string           `json:"updatedAt"`
+	Archived    bool             `json:"archived"`
+	FieldGroups []FormFieldGroup `json:"fieldGroups,omitempty"`
+}
+
+// FormFieldGroup represents a group of fields in a form
+type FormFieldGroup struct {
+	GroupType    string      `json:"groupType"`
+	RichTextType string      `json:"richTextType,omitempty"`
+	Fields       []FormField `json:"fields,omitempty"`
+}
+
+// FormField represents a field in a form
+type FormField struct {
+	Name      string `json:"name"`
+	Label     string `json:"label"`
+	FieldType string `json:"fieldType"`
+	Required  bool   `json:"required"`
+	Hidden    bool   `json:"hidden"`
+}
+
+// FormList represents a paginated list of forms
+type FormList struct {
+	Results []Form  `json:"results"`
+	Paging  *Paging `json:"paging,omitempty"`
+}
+
+// FormSubmission represents a form submission
+type FormSubmission struct {
+	ID          string                 `json:"id"`
+	SubmittedAt string                 `json:"submittedAt"`
+	Values      map[string]interface{} `json:"values"`
+}
+
+// FormSubmissionList represents a paginated list of form submissions
+type FormSubmissionList struct {
+	Results []FormSubmission `json:"results"`
+	Paging  *Paging          `json:"paging,omitempty"`
+}
+
+// Campaign represents a HubSpot marketing campaign
+type Campaign struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+// CampaignList represents a paginated list of campaigns
+type CampaignList struct {
+	Results []Campaign `json:"results"`
+	Paging  *Paging    `json:"paging,omitempty"`
+}
+
+// ListForms retrieves all forms with pagination
+func (c *Client) ListForms(opts ListOptions) (*FormList, error) {
+	url := fmt.Sprintf("%s/marketing/v3/forms", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result FormList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse forms response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetForm retrieves a single form by ID
+func (c *Client) GetForm(formID string) (*Form, error) {
+	if formID == "" {
+		return nil, fmt.Errorf("form ID is required")
+	}
+
+	url := fmt.Sprintf("%s/marketing/v3/forms/%s", c.BaseURL, formID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Form
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse form response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetFormSubmissions retrieves submissions for a form
+func (c *Client) GetFormSubmissions(formID string, opts ListOptions) (*FormSubmissionList, error) {
+	if formID == "" {
+		return nil, fmt.Errorf("form ID is required")
+	}
+
+	url := fmt.Sprintf("%s/marketing/v3/forms/%s/submissions", c.BaseURL, formID)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result FormSubmissionList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse submissions response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListCampaigns retrieves all campaigns with pagination
+func (c *Client) ListCampaigns(opts ListOptions) (*CampaignList, error) {
+	url := fmt.Sprintf("%s/marketing/v3/campaigns", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result CampaignList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse campaigns response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetCampaign retrieves a single campaign by ID
+func (c *Client) GetCampaign(campaignID string) (*Campaign, error) {
+	if campaignID == "" {
+		return nil, fmt.Errorf("campaign ID is required")
+	}
+
+	url := fmt.Sprintf("%s/marketing/v3/campaigns/%s", c.BaseURL, campaignID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Campaign
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse campaign response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/api/marketing_test.go
+++ b/api/marketing_test.go
@@ -1,0 +1,280 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListForms(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/marketing/v3/forms", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "10", r.URL.Query().Get("limit"))
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "form-123",
+						"name": "Contact Us",
+						"formType": "hubspot",
+						"createdAt": "2024-01-15T10:00:00Z",
+						"updatedAt": "2024-01-16T12:00:00Z",
+						"archived": false
+					}
+				],
+				"paging": {
+					"next": {
+						"after": "abc123"
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListForms(ListOptions{Limit: 10})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "form-123", result.Results[0].ID)
+		assert.Equal(t, "Contact Us", result.Results[0].Name)
+		assert.Equal(t, "abc123", result.Paging.Next.After)
+	})
+
+	t.Run("empty results", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListForms(ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, result.Results)
+	})
+}
+
+func TestClient_GetForm(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/marketing/v3/forms/form-123", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "form-123",
+				"name": "Contact Us",
+				"formType": "hubspot",
+				"createdAt": "2024-01-15T10:00:00Z",
+				"updatedAt": "2024-01-16T12:00:00Z",
+				"archived": false,
+				"fieldGroups": [
+					{
+						"groupType": "default_group",
+						"fields": [
+							{
+								"name": "email",
+								"label": "Email",
+								"fieldType": "email",
+								"required": true,
+								"hidden": false
+							}
+						]
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		form, err := client.GetForm("form-123")
+		require.NoError(t, err)
+		assert.Equal(t, "form-123", form.ID)
+		assert.Equal(t, "Contact Us", form.Name)
+		assert.Len(t, form.FieldGroups, 1)
+		assert.Len(t, form.FieldGroups[0].Fields, 1)
+		assert.Equal(t, "email", form.FieldGroups[0].Fields[0].Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Form not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		form, err := client.GetForm("nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, form)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		form, err := client.GetForm("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "form ID is required")
+		assert.Nil(t, form)
+	})
+}
+
+func TestClient_GetFormSubmissions(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/marketing/v3/forms/form-123/submissions", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "sub-456",
+						"submittedAt": "2024-01-20T10:00:00Z",
+						"values": {
+							"email": "john@example.com",
+							"firstname": "John"
+						}
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.GetFormSubmissions("form-123", ListOptions{})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "sub-456", result.Results[0].ID)
+		assert.Equal(t, "john@example.com", result.Results[0].Values["email"])
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		result, err := client.GetFormSubmissions("", ListOptions{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "form ID is required")
+		assert.Nil(t, result)
+	})
+}
+
+func TestClient_ListCampaigns(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/marketing/v3/campaigns", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "campaign-123",
+						"name": "Q1 Launch",
+						"createdAt": "2024-01-01T10:00:00Z",
+						"updatedAt": "2024-01-15T12:00:00Z"
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListCampaigns(ListOptions{})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "campaign-123", result.Results[0].ID)
+		assert.Equal(t, "Q1 Launch", result.Results[0].Name)
+	})
+}
+
+func TestClient_GetCampaign(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/marketing/v3/campaigns/campaign-123", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "campaign-123",
+				"name": "Q1 Launch",
+				"createdAt": "2024-01-01T10:00:00Z",
+				"updatedAt": "2024-01-15T12:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		campaign, err := client.GetCampaign("campaign-123")
+		require.NoError(t, err)
+		assert.Equal(t, "campaign-123", campaign.ID)
+		assert.Equal(t, "Q1 Launch", campaign.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Campaign not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		campaign, err := client.GetCampaign("nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, campaign)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		campaign, err := client.GetCampaign("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "campaign ID is required")
+		assert.Nil(t, campaign)
+	})
+}

--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/campaigns"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/companies"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/completion"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/configcmd"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/contacts"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/deals"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/forms"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/initcmd"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/owners"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
@@ -37,6 +39,10 @@ func run() error {
 	deals.Register(rootCmd, opts)
 	tickets.Register(rootCmd, opts)
 	owners.Register(rootCmd, opts)
+
+	// Marketing commands
+	forms.Register(rootCmd, opts)
+	campaigns.Register(rootCmd, opts)
 
 	return rootCmd.Execute()
 }

--- a/internal/cmd/campaigns/campaigns.go
+++ b/internal/cmd/campaigns/campaigns.go
@@ -1,0 +1,124 @@
+package campaigns
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the campaigns command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "campaigns",
+		Short: "Manage HubSpot marketing campaigns",
+		Long:  "Commands for listing and viewing marketing campaigns in HubSpot.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List campaigns",
+		Long:  "List marketing campaigns from HubSpot with pagination support.",
+		Example: `  # List first 10 campaigns
+  hspt campaigns list
+
+  # List with pagination
+  hspt campaigns list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListCampaigns(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No campaigns found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "CREATED", "UPDATED"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, campaign := range result.Results {
+				rows = append(rows, []string{
+					campaign.ID,
+					campaign.Name,
+					campaign.CreatedAt,
+					campaign.UpdatedAt,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of campaigns to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a campaign by ID",
+		Long:  "Retrieve a single campaign by its ID from HubSpot.",
+		Example: `  # Get campaign by ID
+  hspt campaigns get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			campaign, err := client.GetCampaign(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Campaign %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", campaign.ID},
+				{"Name", campaign.Name},
+				{"Created", campaign.CreatedAt},
+				{"Updated", campaign.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, campaign)
+		},
+	}
+}

--- a/internal/cmd/forms/forms.go
+++ b/internal/cmd/forms/forms.go
@@ -1,0 +1,244 @@
+package forms
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the forms command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "forms",
+		Short: "Manage HubSpot forms",
+		Long:  "Commands for listing and viewing forms and their submissions in HubSpot.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newSubmissionsCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List forms",
+		Long:  "List forms from HubSpot with pagination support.",
+		Example: `  # List first 10 forms
+  hspt forms list
+
+  # List with pagination
+  hspt forms list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListForms(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No forms found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "TYPE", "ARCHIVED", "CREATED"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, form := range result.Results {
+				archived := "No"
+				if form.Archived {
+					archived = "Yes"
+				}
+				rows = append(rows, []string{
+					form.ID,
+					form.Name,
+					form.FormType,
+					archived,
+					form.CreatedAt,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of forms to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a form by ID",
+		Long:  "Retrieve a single form by its ID from HubSpot.",
+		Example: `  # Get form by ID
+  hspt forms get abc123-def456`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			form, err := client.GetForm(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Form %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", form.ID},
+				{"Name", form.Name},
+				{"Type", form.FormType},
+				{"Archived", formatBool(form.Archived)},
+				{"Created", form.CreatedAt},
+				{"Updated", form.UpdatedAt},
+			}
+
+			// Add field count
+			fieldCount := 0
+			for _, group := range form.FieldGroups {
+				fieldCount += len(group.Fields)
+			}
+			rows = append(rows, []string{"Fields", fmt.Sprintf("%d", fieldCount)})
+
+			if err := v.Render(headers, rows, form); err != nil {
+				return err
+			}
+
+			// Show fields in verbose mode
+			if opts.Verbose && len(form.FieldGroups) > 0 {
+				v.Println("")
+				v.Info("Form Fields:")
+				fieldHeaders := []string{"NAME", "LABEL", "TYPE", "REQUIRED"}
+				fieldRows := make([][]string, 0)
+				for _, group := range form.FieldGroups {
+					for _, field := range group.Fields {
+						fieldRows = append(fieldRows, []string{
+							field.Name,
+							field.Label,
+							field.FieldType,
+							formatBool(field.Required),
+						})
+					}
+				}
+				if len(fieldRows) > 0 {
+					return v.Render(fieldHeaders, fieldRows, nil)
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+func newSubmissionsCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "submissions <form-id>",
+		Short: "List form submissions",
+		Long:  "List submissions for a specific form.",
+		Example: `  # List submissions for a form
+  hspt forms submissions abc123-def456
+
+  # With pagination
+  hspt forms submissions abc123-def456 --limit 50`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			formID := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.GetFormSubmissions(formID, api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Form %s not found", formID)
+					return nil
+				}
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No submissions found for form %s", formID)
+				return nil
+			}
+
+			// For submissions, we show a summary since values vary per form
+			headers := []string{"ID", "SUBMITTED AT", "FIELD COUNT"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, sub := range result.Results {
+				rows = append(rows, []string{
+					sub.ID,
+					sub.SubmittedAt,
+					fmt.Sprintf("%d", len(sub.Values)),
+				})
+			}
+
+			v.Info("Found %d submission(s)", len(result.Results))
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of submissions to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}


### PR DESCRIPTION
## Summary
- Add `api/marketing.go` with Forms and Campaigns API client methods
- Implement CLI commands:
  - **forms**: list, get, submissions
  - **campaigns**: list, get
- 10 new tests for Marketing API methods

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes
- [x] `hspt forms --help` shows subcommands
- [x] `hspt campaigns --help` shows subcommands

## Note
This is a partial implementation of #5. Marketing Emails and Email Events APIs have more complex structures and will be addressed in follow-up issues.

Closes #5