### PR TITLE
feat: add CMS API commands (files, domains)

### DIFF
--- a/api/cms.go
+++ b/api/cms.go
@@ -1,0 +1,213 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// File represents a HubSpot file
+type File struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	Type        string `json:"type"`
+	Extension   string `json:"extension"`
+	URL         string `json:"url"`
+	AccessLevel string `json:"access"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+	Archived    bool   `json:"archived"`
+}
+
+// FileList represents a paginated list of files
+type FileList struct {
+	Results []File  `json:"results"`
+	Paging  *Paging `json:"paging,omitempty"`
+}
+
+// Folder represents a HubSpot folder
+type Folder struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Path      string `json:"path"`
+	ParentID  string `json:"parentFolderId,omitempty"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+	Archived  bool   `json:"archived"`
+}
+
+// FolderList represents a paginated list of folders
+type FolderList struct {
+	Results []Folder `json:"results"`
+	Paging  *Paging  `json:"paging,omitempty"`
+}
+
+// Domain represents a HubSpot domain
+type Domain struct {
+	ID                   string `json:"id"`
+	Domain               string `json:"domain"`
+	PrimaryLandingPage   bool   `json:"primaryLandingPage"`
+	PrimaryEmail         bool   `json:"primaryEmail"`
+	PrimaryBlogPost      bool   `json:"primaryBlogPost"`
+	PrimarySitePage      bool   `json:"primarySitePage"`
+	PrimaryKnowledge     bool   `json:"primaryKnowledge"`
+	IsResolving          bool   `json:"isResolving"`
+	IsSslEnabled         bool   `json:"isSslEnabled"`
+	IsSslOnly            bool   `json:"isSslOnly"`
+	IsUsedForBlogPost    bool   `json:"isUsedForBlogPost"`
+	IsUsedForSitePage    bool   `json:"isUsedForSitePage"`
+	IsUsedForLandingPage bool   `json:"isUsedForLandingPage"`
+	IsUsedForEmail       bool   `json:"isUsedForEmail"`
+	IsUsedForKnowledge   bool   `json:"isUsedForKnowledge"`
+	CreatedAt            string `json:"createdAt"`
+	UpdatedAt            string `json:"updatedAt"`
+}
+
+// DomainList represents a paginated list of domains
+type DomainList struct {
+	Results []Domain `json:"results"`
+	Paging  *Paging  `json:"paging,omitempty"`
+}
+
+// ListFiles retrieves files with pagination
+func (c *Client) ListFiles(opts ListOptions) (*FileList, error) {
+	url := fmt.Sprintf("%s/files/v3/files", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result FileList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse files response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetFile retrieves a single file by ID
+func (c *Client) GetFile(fileID string) (*File, error) {
+	if fileID == "" {
+		return nil, fmt.Errorf("file ID is required")
+	}
+
+	url := fmt.Sprintf("%s/files/v3/files/%s", c.BaseURL, fileID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result File
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse file response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteFile deletes a file by ID
+func (c *Client) DeleteFile(fileID string) error {
+	if fileID == "" {
+		return fmt.Errorf("file ID is required")
+	}
+
+	url := fmt.Sprintf("%s/files/v3/files/%s", c.BaseURL, fileID)
+
+	_, err := c.delete(url)
+	return err
+}
+
+// ListFolders retrieves folders with pagination
+func (c *Client) ListFolders(opts ListOptions) (*FolderList, error) {
+	url := fmt.Sprintf("%s/files/v3/folders", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result FolderList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse folders response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListDomains retrieves domains with pagination
+func (c *Client) ListDomains(opts ListOptions) (*DomainList, error) {
+	url := fmt.Sprintf("%s/cms/v3/domains", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result DomainList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse domains response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetDomain retrieves a single domain by ID
+func (c *Client) GetDomain(domainID string) (*Domain, error) {
+	if domainID == "" {
+		return nil, fmt.Errorf("domain ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/domains/%s", c.BaseURL, domainID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Domain
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse domain response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/api/cms_test.go
+++ b/api/cms_test.go
@@ -1,0 +1,307 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListFiles(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/files/v3/files", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "10", r.URL.Query().Get("limit"))
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "file-123",
+						"name": "image.png",
+						"path": "/images/image.png",
+						"size": 12345,
+						"type": "IMG",
+						"extension": "png",
+						"url": "https://example.com/image.png",
+						"access": "PUBLIC_INDEXABLE",
+						"createdAt": "2024-01-15T10:00:00Z",
+						"updatedAt": "2024-01-16T12:00:00Z",
+						"archived": false
+					}
+				],
+				"paging": {
+					"next": {
+						"after": "abc123"
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListFiles(ListOptions{Limit: 10})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "file-123", result.Results[0].ID)
+		assert.Equal(t, "image.png", result.Results[0].Name)
+		assert.Equal(t, int64(12345), result.Results[0].Size)
+		assert.Equal(t, "abc123", result.Paging.Next.After)
+	})
+
+	t.Run("empty results", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListFiles(ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, result.Results)
+	})
+}
+
+func TestClient_GetFile(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/files/v3/files/file-123", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "file-123",
+				"name": "document.pdf",
+				"path": "/docs/document.pdf",
+				"size": 54321,
+				"type": "DOCUMENT",
+				"extension": "pdf",
+				"url": "https://example.com/document.pdf",
+				"access": "PRIVATE",
+				"createdAt": "2024-01-15T10:00:00Z",
+				"updatedAt": "2024-01-16T12:00:00Z",
+				"archived": false
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		file, err := client.GetFile("file-123")
+		require.NoError(t, err)
+		assert.Equal(t, "file-123", file.ID)
+		assert.Equal(t, "document.pdf", file.Name)
+		assert.Equal(t, "PRIVATE", file.AccessLevel)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "File not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		file, err := client.GetFile("nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, file)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		file, err := client.GetFile("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "file ID is required")
+		assert.Nil(t, file)
+	})
+}
+
+func TestClient_DeleteFile(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/files/v3/files/file-123", r.URL.Path)
+			assert.Equal(t, http.MethodDelete, r.Method)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		err := client.DeleteFile("file-123")
+		require.NoError(t, err)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		err := client.DeleteFile("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "file ID is required")
+	})
+}
+
+func TestClient_ListFolders(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/files/v3/folders", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "folder-123",
+						"name": "images",
+						"path": "/images",
+						"createdAt": "2024-01-15T10:00:00Z",
+						"updatedAt": "2024-01-16T12:00:00Z",
+						"archived": false
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListFolders(ListOptions{})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "folder-123", result.Results[0].ID)
+		assert.Equal(t, "images", result.Results[0].Name)
+	})
+}
+
+func TestClient_ListDomains(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/domains", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "domain-123",
+						"domain": "www.example.com",
+						"primarySitePage": true,
+						"isResolving": true,
+						"isSslEnabled": true,
+						"isSslOnly": true,
+						"createdAt": "2024-01-15T10:00:00Z",
+						"updatedAt": "2024-01-16T12:00:00Z"
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListDomains(ListOptions{})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "domain-123", result.Results[0].ID)
+		assert.Equal(t, "www.example.com", result.Results[0].Domain)
+		assert.True(t, result.Results[0].PrimarySitePage)
+		assert.True(t, result.Results[0].IsSslEnabled)
+	})
+}
+
+func TestClient_GetDomain(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/domains/domain-123", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "domain-123",
+				"domain": "blog.example.com",
+				"primaryBlogPost": true,
+				"isResolving": true,
+				"isSslEnabled": true,
+				"isSslOnly": false,
+				"isUsedForBlogPost": true,
+				"createdAt": "2024-01-15T10:00:00Z",
+				"updatedAt": "2024-01-16T12:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		domain, err := client.GetDomain("domain-123")
+		require.NoError(t, err)
+		assert.Equal(t, "domain-123", domain.ID)
+		assert.Equal(t, "blog.example.com", domain.Domain)
+		assert.True(t, domain.PrimaryBlogPost)
+		assert.True(t, domain.IsUsedForBlogPost)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Domain not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		domain, err := client.GetDomain("nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, domain)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		domain, err := client.GetDomain("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "domain ID is required")
+		assert.Nil(t, domain)
+	})
+}

--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/configcmd"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/contacts"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/deals"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/domains"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/files"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/forms"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/initcmd"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/owners"
@@ -43,6 +45,10 @@ func run() error {
 	// Marketing commands
 	forms.Register(rootCmd, opts)
 	campaigns.Register(rootCmd, opts)
+
+	// CMS commands
+	files.Register(rootCmd, opts)
+	domains.Register(rootCmd, opts)
 
 	return rootCmd.Execute()
 }

--- a/internal/cmd/domains/domains.go
+++ b/internal/cmd/domains/domains.go
@@ -1,0 +1,164 @@
+package domains
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the domains command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "domains",
+		Short: "Manage HubSpot domains",
+		Long:  "Commands for listing and viewing domains configured in HubSpot.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List domains",
+		Long:  "List domains configured in HubSpot with pagination support.",
+		Example: `  # List all domains
+  hspt domains list
+
+  # List with pagination
+  hspt domains list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListDomains(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No domains found")
+				return nil
+			}
+
+			headers := []string{"ID", "DOMAIN", "SSL", "RESOLVING", "PRIMARY FOR"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, domain := range result.Results {
+				primaryFor := getPrimaryUses(&domain)
+				rows = append(rows, []string{
+					domain.ID,
+					domain.Domain,
+					formatBool(domain.IsSslEnabled),
+					formatBool(domain.IsResolving),
+					primaryFor,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of domains to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a domain by ID",
+		Long:  "Retrieve a single domain by its ID.",
+		Example: `  # Get domain by ID
+  hspt domains get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			domain, err := client.GetDomain(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Domain %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", domain.ID},
+				{"Domain", domain.Domain},
+				{"SSL Enabled", formatBool(domain.IsSslEnabled)},
+				{"SSL Only", formatBool(domain.IsSslOnly)},
+				{"Resolving", formatBool(domain.IsResolving)},
+				{"Primary Site Page", formatBool(domain.PrimarySitePage)},
+				{"Primary Landing Page", formatBool(domain.PrimaryLandingPage)},
+				{"Primary Blog Post", formatBool(domain.PrimaryBlogPost)},
+				{"Primary Email", formatBool(domain.PrimaryEmail)},
+				{"Used for Site Pages", formatBool(domain.IsUsedForSitePage)},
+				{"Used for Landing Pages", formatBool(domain.IsUsedForLandingPage)},
+				{"Used for Blog Posts", formatBool(domain.IsUsedForBlogPost)},
+				{"Used for Email", formatBool(domain.IsUsedForEmail)},
+				{"Created", domain.CreatedAt},
+				{"Updated", domain.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, domain)
+		},
+	}
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}
+
+func getPrimaryUses(d *api.Domain) string {
+	uses := ""
+	if d.PrimarySitePage {
+		uses += "Site, "
+	}
+	if d.PrimaryLandingPage {
+		uses += "Landing, "
+	}
+	if d.PrimaryBlogPost {
+		uses += "Blog, "
+	}
+	if d.PrimaryEmail {
+		uses += "Email, "
+	}
+	if len(uses) > 2 {
+		return uses[:len(uses)-2]
+	}
+	return "-"
+}

--- a/internal/cmd/files/files.go
+++ b/internal/cmd/files/files.go
@@ -1,0 +1,267 @@
+package files
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the files command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "files",
+		Short: "Manage HubSpot files",
+		Long:  "Commands for listing and viewing files in the HubSpot File Manager.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+	cmd.AddCommand(newFoldersCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List files",
+		Long:  "List files from the HubSpot File Manager with pagination support.",
+		Example: `  # List first 10 files
+  hspt files list
+
+  # List with pagination
+  hspt files list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListFiles(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No files found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "TYPE", "SIZE", "ACCESS"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, file := range result.Results {
+				rows = append(rows, []string{
+					file.ID,
+					file.Name,
+					file.Type,
+					formatSize(file.Size),
+					file.AccessLevel,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of files to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a file by ID",
+		Long:  "Retrieve a single file by its ID from the HubSpot File Manager.",
+		Example: `  # Get file by ID
+  hspt files get 12345678`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			file, err := client.GetFile(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("File %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", file.ID},
+				{"Name", file.Name},
+				{"Path", file.Path},
+				{"Type", file.Type},
+				{"Extension", file.Extension},
+				{"Size", formatSize(file.Size)},
+				{"Access", file.AccessLevel},
+				{"URL", file.URL},
+				{"Archived", formatBool(file.Archived)},
+				{"Created", file.CreatedAt},
+				{"Updated", file.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, file)
+		},
+	}
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a file",
+		Long:  "Delete a file from the HubSpot File Manager.",
+		Example: `  # Delete file
+  hspt files delete 12345678
+
+  # Delete without confirmation
+  hspt files delete 12345678 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will permanently delete file %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteFile(id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("File %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("File %s deleted", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func newFoldersCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "folders",
+		Short: "List folders",
+		Long:  "List folders from the HubSpot File Manager.",
+		Example: `  # List folders
+  hspt files folders`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListFolders(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No folders found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "PATH", "ARCHIVED"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, folder := range result.Results {
+				rows = append(rows, []string{
+					folder.ID,
+					folder.Name,
+					folder.Path,
+					formatBool(folder.Archived),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of folders to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func formatSize(bytes int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+	)
+
+	switch {
+	case bytes >= GB:
+		return fmt.Sprintf("%.2f GB", float64(bytes)/GB)
+	case bytes >= MB:
+		return fmt.Sprintf("%.2f MB", float64(bytes)/MB)
+	case bytes >= KB:
+		return fmt.Sprintf("%.2f KB", float64(bytes)/KB)
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}


### PR DESCRIPTION
## Summary
- Add `api/cms.go` with Files and Domains API client methods
- Implement CLI commands:
  - **files**: list, get, delete, folders
  - **domains**: list, get
- 11 new tests for CMS API methods

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes
- [x] `hspt files --help` shows subcommands
- [x] `hspt domains --help` shows subcommands

## Note
This is a partial implementation of #6. Pages, blog-posts, HubDB APIs will be addressed in follow-up issues.

Closes #6