### PR TITLE
feat: add Conversations API commands (inboxes, threads)

### DIFF
--- a/api/conversations.go
+++ b/api/conversations.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Inbox represents a HubSpot conversations inbox
+type Inbox struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+	Archived  bool   `json:"archived"`
+}
+
+// InboxList represents a paginated list of inboxes
+type InboxList struct {
+	Results []Inbox `json:"results"`
+	Paging  *Paging `json:"paging,omitempty"`
+}
+
+// Thread represents a HubSpot conversations thread
+type Thread struct {
+	ID                  string `json:"id"`
+	Status              string `json:"status"`
+	AssociatedContactID string `json:"associatedContactId,omitempty"`
+	InboxID             string `json:"inboxId,omitempty"`
+	CreatedAt           string `json:"createdAt"`
+	UpdatedAt           string `json:"updatedAt"`
+	ClosedAt            string `json:"closedAt,omitempty"`
+	Archived            bool   `json:"archived"`
+}
+
+// ThreadList represents a paginated list of threads
+type ThreadList struct {
+	Results []Thread `json:"results"`
+	Paging  *Paging  `json:"paging,omitempty"`
+}
+
+// ListInboxes retrieves inboxes with pagination
+func (c *Client) ListInboxes(opts ListOptions) (*InboxList, error) {
+	url := fmt.Sprintf("%s/conversations/v3/conversations/inboxes", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result InboxList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse inboxes response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetInbox retrieves a single inbox by ID
+func (c *Client) GetInbox(inboxID string) (*Inbox, error) {
+	if inboxID == "" {
+		return nil, fmt.Errorf("inbox ID is required")
+	}
+
+	url := fmt.Sprintf("%s/conversations/v3/conversations/inboxes/%s", c.BaseURL, inboxID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Inbox
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse inbox response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListThreads retrieves threads with pagination
+func (c *Client) ListThreads(opts ListOptions) (*ThreadList, error) {
+	url := fmt.Sprintf("%s/conversations/v3/conversations/threads", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result ThreadList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse threads response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetThread retrieves a single thread by ID
+func (c *Client) GetThread(threadID string) (*Thread, error) {
+	if threadID == "" {
+		return nil, fmt.Errorf("thread ID is required")
+	}
+
+	url := fmt.Sprintf("%s/conversations/v3/conversations/threads/%s", c.BaseURL, threadID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Thread
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse thread response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/api/conversations_test.go
+++ b/api/conversations_test.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListInboxes(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/conversations/v3/conversations/inboxes", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "inbox-123",
+						"name": "Support",
+						"createdAt": "2024-01-15T10:00:00Z",
+						"updatedAt": "2024-01-16T12:00:00Z",
+						"archived": false
+					}
+				],
+				"paging": {
+					"next": {
+						"after": "abc123"
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListInboxes(ListOptions{Limit: 10})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "inbox-123", result.Results[0].ID)
+		assert.Equal(t, "Support", result.Results[0].Name)
+		assert.Equal(t, "abc123", result.Paging.Next.After)
+	})
+
+	t.Run("empty results", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListInboxes(ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, result.Results)
+	})
+}
+
+func TestClient_GetInbox(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/conversations/v3/conversations/inboxes/inbox-123", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "inbox-123",
+				"name": "Support",
+				"createdAt": "2024-01-15T10:00:00Z",
+				"updatedAt": "2024-01-16T12:00:00Z",
+				"archived": false
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		inbox, err := client.GetInbox("inbox-123")
+		require.NoError(t, err)
+		assert.Equal(t, "inbox-123", inbox.ID)
+		assert.Equal(t, "Support", inbox.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Inbox not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		inbox, err := client.GetInbox("nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, inbox)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		inbox, err := client.GetInbox("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "inbox ID is required")
+		assert.Nil(t, inbox)
+	})
+}
+
+func TestClient_ListThreads(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/conversations/v3/conversations/threads", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "thread-123",
+						"status": "OPEN",
+						"associatedContactId": "contact-456",
+						"inboxId": "inbox-789",
+						"createdAt": "2024-01-15T10:00:00Z",
+						"updatedAt": "2024-01-16T12:00:00Z",
+						"archived": false
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListThreads(ListOptions{})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "thread-123", result.Results[0].ID)
+		assert.Equal(t, "OPEN", result.Results[0].Status)
+		assert.Equal(t, "contact-456", result.Results[0].AssociatedContactID)
+	})
+}
+
+func TestClient_GetThread(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/conversations/v3/conversations/threads/thread-123", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "thread-123",
+				"status": "CLOSED",
+				"associatedContactId": "contact-456",
+				"inboxId": "inbox-789",
+				"createdAt": "2024-01-15T10:00:00Z",
+				"updatedAt": "2024-01-16T12:00:00Z",
+				"closedAt": "2024-01-16T14:00:00Z",
+				"archived": false
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		thread, err := client.GetThread("thread-123")
+		require.NoError(t, err)
+		assert.Equal(t, "thread-123", thread.ID)
+		assert.Equal(t, "CLOSED", thread.Status)
+		assert.Equal(t, "2024-01-16T14:00:00Z", thread.ClosedAt)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Thread not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		thread, err := client.GetThread("nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, thread)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		thread, err := client.GetThread("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "thread ID is required")
+		assert.Nil(t, thread)
+	})
+}

--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/completion"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/configcmd"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/contacts"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/conversations"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/deals"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/domains"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/files"
@@ -49,6 +50,9 @@ func run() error {
 	// CMS commands
 	files.Register(rootCmd, opts)
 	domains.Register(rootCmd, opts)
+
+	// Conversations commands
+	conversations.Register(rootCmd, opts)
 
 	return rootCmd.Execute()
 }

--- a/internal/cmd/conversations/conversations.go
+++ b/internal/cmd/conversations/conversations.go
@@ -1,0 +1,262 @@
+package conversations
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the conversations command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "conversations",
+		Short: "Manage HubSpot conversations",
+		Long:  "Commands for listing and viewing conversations inboxes and threads.",
+	}
+
+	cmd.AddCommand(newInboxesCmd(opts))
+	cmd.AddCommand(newThreadsCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newInboxesCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "inboxes",
+		Short: "Manage inboxes",
+		Long:  "Commands for listing and viewing conversation inboxes.",
+	}
+
+	cmd.AddCommand(newInboxesListCmd(opts))
+	cmd.AddCommand(newInboxesGetCmd(opts))
+
+	return cmd
+}
+
+func newInboxesListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List inboxes",
+		Long:  "List conversation inboxes from HubSpot.",
+		Example: `  # List inboxes
+  hspt conversations inboxes list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListInboxes(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No inboxes found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "ARCHIVED", "CREATED"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, inbox := range result.Results {
+				rows = append(rows, []string{
+					inbox.ID,
+					inbox.Name,
+					formatBool(inbox.Archived),
+					inbox.CreatedAt,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of inboxes to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newInboxesGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get an inbox by ID",
+		Long:  "Retrieve a single inbox by its ID.",
+		Example: `  # Get inbox by ID
+  hspt conversations inboxes get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			inbox, err := client.GetInbox(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Inbox %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", inbox.ID},
+				{"Name", inbox.Name},
+				{"Archived", formatBool(inbox.Archived)},
+				{"Created", inbox.CreatedAt},
+				{"Updated", inbox.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, inbox)
+		},
+	}
+}
+
+func newThreadsCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "threads",
+		Short: "Manage threads",
+		Long:  "Commands for listing and viewing conversation threads.",
+	}
+
+	cmd.AddCommand(newThreadsListCmd(opts))
+	cmd.AddCommand(newThreadsGetCmd(opts))
+
+	return cmd
+}
+
+func newThreadsListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List threads",
+		Long:  "List conversation threads from HubSpot.",
+		Example: `  # List threads
+  hspt conversations threads list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListThreads(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No threads found")
+				return nil
+			}
+
+			headers := []string{"ID", "STATUS", "INBOX ID", "CONTACT ID", "CREATED"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, thread := range result.Results {
+				rows = append(rows, []string{
+					thread.ID,
+					thread.Status,
+					thread.InboxID,
+					thread.AssociatedContactID,
+					thread.CreatedAt,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of threads to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newThreadsGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a thread by ID",
+		Long:  "Retrieve a single thread by its ID.",
+		Example: `  # Get thread by ID
+  hspt conversations threads get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			thread, err := client.GetThread(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Thread %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", thread.ID},
+				{"Status", thread.Status},
+				{"Inbox ID", thread.InboxID},
+				{"Contact ID", thread.AssociatedContactID},
+				{"Archived", formatBool(thread.Archived)},
+				{"Created", thread.CreatedAt},
+				{"Updated", thread.UpdatedAt},
+			}
+
+			if thread.ClosedAt != "" {
+				rows = append(rows, []string{"Closed", thread.ClosedAt})
+			}
+
+			return v.Render(headers, rows, thread)
+		},
+	}
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}


### PR DESCRIPTION
## Summary
- Implements Conversations API client methods (ListInboxes, GetInbox, ListThreads, GetThread)
- Adds CLI commands for managing HubSpot inboxes and conversation threads
- Includes comprehensive test coverage for API methods

## Commands Added
```
hspt conversations inboxes list [--limit N] [--after cursor]
hspt conversations inboxes get <id>
hspt conversations threads list [--limit N] [--after cursor]
hspt conversations threads get <id>
```

## Test plan
- [x] Unit tests for all API methods
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes

Closes #7