### PR TITLE
feat: add Automation API commands (workflows)

### DIFF
--- a/api/automation.go
+++ b/api/automation.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Workflow represents a HubSpot automation workflow
+type Workflow struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	Enabled      bool   `json:"isEnabled"`
+	ObjectTypeID string `json:"objectTypeId,omitempty"`
+	RevisionID   string `json:"revisionId,omitempty"`
+	CreatedAt    string `json:"createdAt,omitempty"`
+	UpdatedAt    string `json:"updatedAt,omitempty"`
+}
+
+// WorkflowList represents a paginated list of workflows
+type WorkflowList struct {
+	Results []Workflow `json:"results"`
+	Paging  *Paging    `json:"paging,omitempty"`
+}
+
+// ListWorkflows retrieves workflows with pagination
+func (c *Client) ListWorkflows(opts ListOptions) (*WorkflowList, error) {
+	url := fmt.Sprintf("%s/automation/v4/flows", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result WorkflowList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse workflows response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetWorkflow retrieves a single workflow by ID
+func (c *Client) GetWorkflow(workflowID string) (*Workflow, error) {
+	if workflowID == "" {
+		return nil, fmt.Errorf("workflow ID is required")
+	}
+
+	url := fmt.Sprintf("%s/automation/v4/flows/%s", c.BaseURL, workflowID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Workflow
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse workflow response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/api/automation_test.go
+++ b/api/automation_test.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListWorkflows(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/automation/v4/flows", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "workflow-123",
+						"name": "Welcome Email",
+						"type": "CONTACT_FLOW",
+						"isEnabled": true,
+						"objectTypeId": "0-1",
+						"revisionId": "rev-456",
+						"createdAt": "2024-01-15T10:00:00Z",
+						"updatedAt": "2024-01-16T12:00:00Z"
+					}
+				],
+				"paging": {
+					"next": {
+						"after": "abc123"
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListWorkflows(ListOptions{Limit: 10})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "workflow-123", result.Results[0].ID)
+		assert.Equal(t, "Welcome Email", result.Results[0].Name)
+		assert.Equal(t, "CONTACT_FLOW", result.Results[0].Type)
+		assert.True(t, result.Results[0].Enabled)
+		assert.Equal(t, "abc123", result.Paging.Next.After)
+	})
+
+	t.Run("empty results", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListWorkflows(ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, result.Results)
+	})
+}
+
+func TestClient_GetWorkflow(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/automation/v4/flows/workflow-123", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "workflow-123",
+				"name": "Welcome Email",
+				"type": "CONTACT_FLOW",
+				"isEnabled": true,
+				"objectTypeId": "0-1",
+				"revisionId": "rev-456",
+				"createdAt": "2024-01-15T10:00:00Z",
+				"updatedAt": "2024-01-16T12:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		workflow, err := client.GetWorkflow("workflow-123")
+		require.NoError(t, err)
+		assert.Equal(t, "workflow-123", workflow.ID)
+		assert.Equal(t, "Welcome Email", workflow.Name)
+		assert.Equal(t, "CONTACT_FLOW", workflow.Type)
+		assert.True(t, workflow.Enabled)
+		assert.Equal(t, "0-1", workflow.ObjectTypeID)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Workflow not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		workflow, err := client.GetWorkflow("nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, workflow)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		workflow, err := client.GetWorkflow("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "workflow ID is required")
+		assert.Nil(t, workflow)
+	})
+}

--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/owners"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/tickets"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/workflows"
 	"github.com/open-cli-collective/hubspot-cli/internal/exitcode"
 )
 
@@ -53,6 +54,9 @@ func run() error {
 
 	// Conversations commands
 	conversations.Register(rootCmd, opts)
+
+	// Automation commands
+	workflows.Register(rootCmd, opts)
 
 	return rootCmd.Execute()
 }

--- a/internal/cmd/workflows/workflows.go
+++ b/internal/cmd/workflows/workflows.go
@@ -1,0 +1,157 @@
+package workflows
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the workflows command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "workflows",
+		Short: "Manage HubSpot workflows",
+		Long:  "Commands for listing and viewing automation workflows.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List workflows",
+		Long:  "List automation workflows from HubSpot.",
+		Example: `  # List workflows
+  hspt workflows list
+
+  # List with pagination
+  hspt workflows list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListWorkflows(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No workflows found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "TYPE", "ENABLED", "OBJECT TYPE"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, workflow := range result.Results {
+				rows = append(rows, []string{
+					workflow.ID,
+					workflow.Name,
+					workflow.Type,
+					formatBool(workflow.Enabled),
+					formatObjectType(workflow.ObjectTypeID),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of workflows to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a workflow by ID",
+		Long:  "Retrieve a single workflow by its ID.",
+		Example: `  # Get workflow by ID
+  hspt workflows get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			workflow, err := client.GetWorkflow(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Workflow %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", workflow.ID},
+				{"Name", workflow.Name},
+				{"Type", workflow.Type},
+				{"Enabled", formatBool(workflow.Enabled)},
+				{"Object Type", formatObjectType(workflow.ObjectTypeID)},
+				{"Revision ID", workflow.RevisionID},
+				{"Created", workflow.CreatedAt},
+				{"Updated", workflow.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, workflow)
+		},
+	}
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}
+
+func formatObjectType(objectTypeID string) string {
+	// HubSpot standard object type IDs
+	objectTypes := map[string]string{
+		"0-1":  "Contacts",
+		"0-2":  "Companies",
+		"0-3":  "Deals",
+		"0-5":  "Tickets",
+		"0-7":  "Products",
+		"0-8":  "Line Items",
+		"0-14": "Quotes",
+	}
+
+	if name, ok := objectTypes[objectTypeID]; ok {
+		return name
+	}
+	if objectTypeID == "" {
+		return "-"
+	}
+	return objectTypeID
+}


### PR DESCRIPTION
## Summary
- Implements Automation API client methods (ListWorkflows, GetWorkflow)
- Adds CLI commands for viewing HubSpot automation workflows
- Includes human-readable object type mapping

## Commands Added
```
hspt workflows list [--limit N] [--after cursor]
hspt workflows get <id>
```

## Scope Notes
Focused on read-only operations. Workflow creation/update/delete are complex operations better suited to the HubSpot UI. Enrollments and custom workflow actions require additional scope/credentials.

## Test plan
- [x] Unit tests for all API methods
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes

Closes #8