### PR TITLE
feat: add GraphQL API commands

### DIFF
--- a/api/graphql.go
+++ b/api/graphql.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GraphQLRequest represents a GraphQL query request
+type GraphQLRequest struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables,omitempty"`
+}
+
+// GraphQLResponse represents a GraphQL query response
+type GraphQLResponse struct {
+	Data   json.RawMessage `json:"data,omitempty"`
+	Errors []GraphQLError  `json:"errors,omitempty"`
+}
+
+// GraphQLError represents a GraphQL error
+type GraphQLError struct {
+	Message    string                 `json:"message"`
+	Locations  []GraphQLLocation      `json:"locations,omitempty"`
+	Path       []interface{}          `json:"path,omitempty"`
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+}
+
+// GraphQLLocation represents a location in a GraphQL query where an error occurred
+type GraphQLLocation struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+// Error returns the error message
+func (e GraphQLError) Error() string {
+	return e.Message
+}
+
+// HasErrors returns true if the response contains errors
+func (r *GraphQLResponse) HasErrors() bool {
+	return len(r.Errors) > 0
+}
+
+// ErrorMessages returns all error messages as a single string
+func (r *GraphQLResponse) ErrorMessages() string {
+	if !r.HasErrors() {
+		return ""
+	}
+	if len(r.Errors) == 1 {
+		return r.Errors[0].Message
+	}
+	msg := ""
+	for i, e := range r.Errors {
+		if i > 0 {
+			msg += "; "
+		}
+		msg += e.Message
+	}
+	return msg
+}
+
+// ExecuteGraphQL executes a GraphQL query
+func (c *Client) ExecuteGraphQL(query string, variables map[string]interface{}) (*GraphQLResponse, error) {
+	if query == "" {
+		return nil, fmt.Errorf("query is required")
+	}
+
+	url := fmt.Sprintf("%s/collector/graphql", c.BaseURL)
+
+	reqBody := GraphQLRequest{
+		Query:     query,
+		Variables: variables,
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal GraphQL request: %w", err)
+	}
+
+	respBytes, err := c.post(url, bodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var result GraphQLResponse
+	if err := json.Unmarshal(respBytes, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/api/graphql_test.go
+++ b/api/graphql_test.go
@@ -1,0 +1,201 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ExecuteGraphQL(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Basic assertions that don't involve reading body
+			if r.URL.Path != "/collector/graphql" {
+				t.Errorf("expected path /collector/graphql, got %s", r.URL.Path)
+			}
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"data": {
+					"CRM": {
+						"contact_collection": {
+							"items": [
+								{"firstname": "John", "lastname": "Doe", "email": "john@example.com"}
+							],
+							"total": 1
+						}
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		query := `query { CRM { contact_collection(limit: 10) { items { firstname lastname email } total } } }`
+		result, err := client.ExecuteGraphQL(query, nil)
+		require.NoError(t, err)
+		assert.False(t, result.HasErrors())
+		assert.NotNil(t, result.Data)
+	})
+
+	t.Run("with variables", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"data": {
+					"CRM": {
+						"contact": {"firstname": "Jane", "email": "jane@example.com"}
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		query := `query GetContact($contactId: ID!) { CRM { contact(id: $contactId) { firstname email } } }`
+		vars := map[string]interface{}{"contactId": "123"}
+		result, err := client.ExecuteGraphQL(query, vars)
+		require.NoError(t, err)
+		assert.False(t, result.HasErrors())
+	})
+
+	t.Run("graphql error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"data": null,
+				"errors": [
+					{
+						"message": "Cannot query field 'invalid_field' on type 'Contact'",
+						"locations": [{"line": 1, "column": 15}],
+						"path": ["CRM", "contact"]
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		query := `query { CRM { contact(id: "123") { invalid_field } } }`
+		result, err := client.ExecuteGraphQL(query, nil)
+		require.NoError(t, err)
+		assert.True(t, result.HasErrors())
+		assert.Len(t, result.Errors, 1)
+		assert.Contains(t, result.Errors[0].Message, "invalid_field")
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"data": null,
+				"errors": [
+					{"message": "Error 1"},
+					{"message": "Error 2"}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ExecuteGraphQL("query { invalid }", nil)
+		require.NoError(t, err)
+		assert.True(t, result.HasErrors())
+		assert.Equal(t, "Error 1; Error 2", result.ErrorMessages())
+	})
+
+	t.Run("empty query", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		result, err := client.ExecuteGraphQL("", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "query is required")
+		assert.Nil(t, result)
+	})
+
+	t.Run("unauthorized", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"status": "error", "message": "Invalid token"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "bad-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ExecuteGraphQL("query { CRM { contact(id: \"123\") { email } } }", nil)
+		assert.Error(t, err)
+		assert.True(t, IsUnauthorized(err))
+		assert.Nil(t, result)
+	})
+}
+
+func TestGraphQLResponse_HasErrors(t *testing.T) {
+	t.Run("no errors", func(t *testing.T) {
+		resp := &GraphQLResponse{
+			Data: json.RawMessage(`{"test": "data"}`),
+		}
+		assert.False(t, resp.HasErrors())
+	})
+
+	t.Run("with errors", func(t *testing.T) {
+		resp := &GraphQLResponse{
+			Errors: []GraphQLError{{Message: "test error"}},
+		}
+		assert.True(t, resp.HasErrors())
+	})
+}
+
+func TestGraphQLResponse_ErrorMessages(t *testing.T) {
+	t.Run("no errors", func(t *testing.T) {
+		resp := &GraphQLResponse{}
+		assert.Equal(t, "", resp.ErrorMessages())
+	})
+
+	t.Run("single error", func(t *testing.T) {
+		resp := &GraphQLResponse{
+			Errors: []GraphQLError{{Message: "Single error"}},
+		}
+		assert.Equal(t, "Single error", resp.ErrorMessages())
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+		resp := &GraphQLResponse{
+			Errors: []GraphQLError{
+				{Message: "First"},
+				{Message: "Second"},
+				{Message: "Third"},
+			},
+		}
+		assert.Equal(t, "First; Second; Third", resp.ErrorMessages())
+	})
+}

--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/domains"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/files"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/forms"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/graphql"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/initcmd"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/owners"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
@@ -57,6 +58,9 @@ func run() error {
 
 	// Automation commands
 	workflows.Register(rootCmd, opts)
+
+	// GraphQL commands
+	graphql.Register(rootCmd, opts)
 
 	return rootCmd.Execute()
 }

--- a/internal/cmd/graphql/graphql.go
+++ b/internal/cmd/graphql/graphql.go
@@ -1,0 +1,121 @@
+package graphql
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the graphql command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "graphql",
+		Short: "Execute GraphQL queries",
+		Long:  "Commands for executing GraphQL queries against HubSpot's unified API.",
+	}
+
+	cmd.AddCommand(newQueryCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newQueryCmd(opts *root.Options) *cobra.Command {
+	var queryFile string
+	var queryString string
+
+	cmd := &cobra.Command{
+		Use:   "query",
+		Short: "Execute a GraphQL query",
+		Long: `Execute a GraphQL query against HubSpot's unified API.
+
+The query can be provided via --file (path to a .graphql file) or
+--query (inline query string). If both are provided, --file takes precedence.`,
+		Example: `  # Execute query from file
+  hspt graphql query --file query.graphql
+
+  # Execute inline query
+  hspt graphql query --query '{ CRM { contact_collection(limit: 10) { items { email } } } }'
+
+  # Query a specific contact
+  hspt graphql query --query '{ CRM { contact(id: "123") { firstname lastname email } } }'
+
+  # Query with associations
+  hspt graphql query --query '{
+    CRM {
+      contact_collection(limit: 5) {
+        items {
+          firstname
+          associations {
+            company_collection {
+              items { name }
+            }
+          }
+        }
+      }
+    }
+  }'`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			// Get query from file or string
+			var query string
+			if queryFile != "" {
+				data, err := os.ReadFile(queryFile)
+				if err != nil {
+					return fmt.Errorf("failed to read query file: %w", err)
+				}
+				query = string(data)
+			} else if queryString != "" {
+				query = queryString
+			} else {
+				return fmt.Errorf("either --file or --query is required")
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ExecuteGraphQL(query, nil)
+			if err != nil {
+				return err
+			}
+
+			// Check for GraphQL errors
+			if result.HasErrors() {
+				v.Error("GraphQL errors: %s", result.ErrorMessages())
+				// Still output the response if there's partial data
+				if result.Data == nil {
+					return nil
+				}
+			}
+
+			// Format and output the data
+			if result.Data != nil {
+				// Pretty print the JSON
+				var prettyJSON json.RawMessage
+				if err := json.Unmarshal(result.Data, &prettyJSON); err != nil {
+					return fmt.Errorf("failed to parse response data: %w", err)
+				}
+
+				formatted, err := json.MarshalIndent(prettyJSON, "", "  ")
+				if err != nil {
+					return fmt.Errorf("failed to format response: %w", err)
+				}
+
+				fmt.Println(string(formatted))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&queryFile, "file", "f", "", "Path to a GraphQL query file")
+	cmd.Flags().StringVarP(&queryString, "query", "q", "", "Inline GraphQL query string")
+
+	return cmd
+}


### PR DESCRIPTION
## Summary
- Implements GraphQL API client method (ExecuteGraphQL)
- Adds CLI command for executing GraphQL queries
- Supports both file-based and inline query inputs

## Commands Added
```
hspt graphql query --file <path>    # Execute query from file
hspt graphql query --query '<gql>'  # Execute inline query
```

## Scope Notes
Focused on query execution. Schema exploration (`explore` command) may be added later as it requires more complex introspection handling.

## Test plan
- [x] Unit tests for API methods
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes

Closes #9