### PR TITLE
feat: add CRM extended object commands (products, line-items, quotes)

### DIFF
--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -16,7 +16,10 @@ import (
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/forms"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/graphql"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/initcmd"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/lineitems"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/owners"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/products"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/quotes"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/tickets"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/workflows"
@@ -44,6 +47,9 @@ func run() error {
 	deals.Register(rootCmd, opts)
 	tickets.Register(rootCmd, opts)
 	owners.Register(rootCmd, opts)
+	products.Register(rootCmd, opts)
+	lineitems.Register(rootCmd, opts)
+	quotes.Register(rootCmd, opts)
 
 	// Marketing commands
 	forms.Register(rootCmd, opts)

--- a/internal/cmd/lineitems/lineitems.go
+++ b/internal/cmd/lineitems/lineitems.go
@@ -1,0 +1,355 @@
+package lineitems
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for line items
+var DefaultProperties = []string{"name", "quantity", "price", "hs_product_id", "amount"}
+
+// Register registers the line-items command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:     "line-items",
+		Aliases: []string{"lineitems"},
+		Short:   "Manage HubSpot line items",
+		Long:    "Commands for listing, viewing, creating, updating, and deleting line items in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List line items",
+		Long:  "List line items from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 line items
+  hspt line-items list
+
+  # List with custom properties
+  hspt line-items list --properties name,quantity,price
+
+  # List with pagination
+  hspt line-items list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeLineItems, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No line items found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "QUANTITY", "PRICE", "AMOUNT", "PRODUCT ID"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("name"),
+					obj.GetProperty("quantity"),
+					obj.GetProperty("price"),
+					obj.GetProperty("amount"),
+					obj.GetProperty("hs_product_id"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of line items to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a line item by ID",
+		Long:  "Retrieve a single line item by its ID from HubSpot CRM.",
+		Example: `  # Get line item by ID
+  hspt line-items get 12345
+
+  # Get with specific properties
+  hspt line-items get 12345 --properties name,quantity,price`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeLineItems, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Line item %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Name", obj.GetProperty("name")},
+				{"Quantity", obj.GetProperty("quantity")},
+				{"Price", obj.GetProperty("price")},
+				{"Amount", obj.GetProperty("amount")},
+				{"Product ID", obj.GetProperty("hs_product_id")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var name, quantity, price, productID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new line item",
+		Long:  "Create a new line item in HubSpot CRM.",
+		Example: `  # Create with common fields
+  hspt line-items create --name "Widget" --quantity 2 --price 99.99
+
+  # Create linked to a product
+  hspt line-items create --name "Widget" --quantity 1 --product-id 12345`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if name != "" {
+				properties["name"] = name
+			}
+			if quantity != "" {
+				properties["quantity"] = quantity
+			}
+			if price != "" {
+				properties["price"] = price
+			}
+			if productID != "" {
+				properties["hs_product_id"] = productID
+			}
+
+			// Parse custom properties
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeLineItems, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Line item created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Name", obj.GetProperty("name")},
+				{"Quantity", obj.GetProperty("quantity")},
+				{"Price", obj.GetProperty("price")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Line item name")
+	cmd.Flags().StringVar(&quantity, "quantity", "", "Quantity")
+	cmd.Flags().StringVar(&price, "price", "", "Unit price")
+	cmd.Flags().StringVar(&productID, "product-id", "", "Associated product ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var name, quantity, price, productID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a line item",
+		Long:  "Update an existing line item in HubSpot CRM.",
+		Example: `  # Update quantity
+  hspt line-items update 12345 --quantity 5
+
+  # Update custom property
+  hspt line-items update 12345 --prop discount=10`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if name != "" {
+				properties["name"] = name
+			}
+			if quantity != "" {
+				properties["quantity"] = quantity
+			}
+			if price != "" {
+				properties["price"] = price
+			}
+			if productID != "" {
+				properties["hs_product_id"] = productID
+			}
+
+			// Parse custom properties
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeLineItems, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Line item %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Line item %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Line item name")
+	cmd.Flags().StringVar(&quantity, "quantity", "", "Quantity")
+	cmd.Flags().StringVar(&price, "price", "", "Unit price")
+	cmd.Flags().StringVar(&productID, "product-id", "", "Associated product ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a line item",
+		Long:  "Archive (soft delete) a line item in HubSpot CRM.",
+		Example: `  # Delete line item
+  hspt line-items delete 12345
+
+  # Delete without confirmation
+  hspt line-items delete 12345 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive line item %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeLineItems, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Line item %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Line item %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -1,0 +1,359 @@
+package products
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for products
+var DefaultProperties = []string{"name", "price", "description", "hs_sku"}
+
+// Register registers the products command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "products",
+		Short: "Manage HubSpot products",
+		Long:  "Commands for listing, viewing, creating, updating, and deleting products in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List products",
+		Long:  "List products from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 products
+  hspt products list
+
+  # List with custom properties
+  hspt products list --properties name,price,hs_sku
+
+  # List with pagination
+  hspt products list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeProducts, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No products found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "PRICE", "SKU", "DESCRIPTION"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("name"),
+					obj.GetProperty("price"),
+					obj.GetProperty("hs_sku"),
+					truncate(obj.GetProperty("description"), 40),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of products to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a product by ID",
+		Long:  "Retrieve a single product by its ID from HubSpot CRM.",
+		Example: `  # Get product by ID
+  hspt products get 12345
+
+  # Get with specific properties
+  hspt products get 12345 --properties name,price,hs_sku`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeProducts, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Product %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Name", obj.GetProperty("name")},
+				{"Price", obj.GetProperty("price")},
+				{"SKU", obj.GetProperty("hs_sku")},
+				{"Description", obj.GetProperty("description")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var name, price, description, sku string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new product",
+		Long:  "Create a new product in HubSpot CRM.",
+		Example: `  # Create with common fields
+  hspt products create --name "Widget" --price 99.99 --sku ABC123
+
+  # Create with custom properties
+  hspt products create --name "Widget" --prop hs_cost_of_goods_sold=50`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if name != "" {
+				properties["name"] = name
+			}
+			if price != "" {
+				properties["price"] = price
+			}
+			if description != "" {
+				properties["description"] = description
+			}
+			if sku != "" {
+				properties["hs_sku"] = sku
+			}
+
+			// Parse custom properties
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeProducts, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Product created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Name", obj.GetProperty("name")},
+				{"Price", obj.GetProperty("price")},
+				{"SKU", obj.GetProperty("hs_sku")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Product name")
+	cmd.Flags().StringVar(&price, "price", "", "Product price")
+	cmd.Flags().StringVar(&description, "description", "", "Product description")
+	cmd.Flags().StringVar(&sku, "sku", "", "Product SKU")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var name, price, description, sku string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a product",
+		Long:  "Update an existing product in HubSpot CRM.",
+		Example: `  # Update product price
+  hspt products update 12345 --price 149.99
+
+  # Update custom property
+  hspt products update 12345 --prop hs_cost_of_goods_sold=75`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if name != "" {
+				properties["name"] = name
+			}
+			if price != "" {
+				properties["price"] = price
+			}
+			if description != "" {
+				properties["description"] = description
+			}
+			if sku != "" {
+				properties["hs_sku"] = sku
+			}
+
+			// Parse custom properties
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeProducts, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Product %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Product %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Product name")
+	cmd.Flags().StringVar(&price, "price", "", "Product price")
+	cmd.Flags().StringVar(&description, "description", "", "Product description")
+	cmd.Flags().StringVar(&sku, "sku", "", "Product SKU")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a product",
+		Long:  "Archive (soft delete) a product in HubSpot CRM.",
+		Example: `  # Delete product
+  hspt products delete 12345
+
+  # Delete without confirmation
+  hspt products delete 12345 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive product %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeProducts, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Product %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Product %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/cmd/quotes/quotes.go
+++ b/internal/cmd/quotes/quotes.go
@@ -1,0 +1,344 @@
+package quotes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for quotes
+var DefaultProperties = []string{"hs_title", "hs_expiration_date", "hs_status", "hs_quote_amount"}
+
+// Register registers the quotes command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "quotes",
+		Short: "Manage HubSpot quotes",
+		Long:  "Commands for listing, viewing, creating, updating, and deleting quotes in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List quotes",
+		Long:  "List quotes from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 quotes
+  hspt quotes list
+
+  # List with custom properties
+  hspt quotes list --properties hs_title,hs_status,hs_quote_amount
+
+  # List with pagination
+  hspt quotes list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeQuotes, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No quotes found")
+				return nil
+			}
+
+			headers := []string{"ID", "TITLE", "STATUS", "AMOUNT", "EXPIRES"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("hs_title"),
+					obj.GetProperty("hs_status"),
+					obj.GetProperty("hs_quote_amount"),
+					obj.GetProperty("hs_expiration_date"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of quotes to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a quote by ID",
+		Long:  "Retrieve a single quote by its ID from HubSpot CRM.",
+		Example: `  # Get quote by ID
+  hspt quotes get 12345
+
+  # Get with specific properties
+  hspt quotes get 12345 --properties hs_title,hs_status,hs_quote_amount`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeQuotes, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Quote %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Title", obj.GetProperty("hs_title")},
+				{"Status", obj.GetProperty("hs_status")},
+				{"Amount", obj.GetProperty("hs_quote_amount")},
+				{"Expiration Date", obj.GetProperty("hs_expiration_date")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var title, status, expirationDate string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new quote",
+		Long:  "Create a new quote in HubSpot CRM.",
+		Example: `  # Create with common fields
+  hspt quotes create --title "Q1 Proposal" --status DRAFT --expiration-date 2024-12-31
+
+  # Create with custom properties
+  hspt quotes create --title "Enterprise Deal" --prop hs_sender_company_name="Acme Corp"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if title != "" {
+				properties["hs_title"] = title
+			}
+			if status != "" {
+				properties["hs_status"] = status
+			}
+			if expirationDate != "" {
+				properties["hs_expiration_date"] = expirationDate
+			}
+
+			// Parse custom properties
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeQuotes, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Quote created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Title", obj.GetProperty("hs_title")},
+				{"Status", obj.GetProperty("hs_status")},
+				{"Expiration Date", obj.GetProperty("hs_expiration_date")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "Quote title")
+	cmd.Flags().StringVar(&status, "status", "", "Quote status (DRAFT, APPROVAL_NOT_NEEDED, etc.)")
+	cmd.Flags().StringVar(&expirationDate, "expiration-date", "", "Quote expiration date (YYYY-MM-DD)")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var title, status, expirationDate string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a quote",
+		Long:  "Update an existing quote in HubSpot CRM.",
+		Example: `  # Update quote status
+  hspt quotes update 12345 --status APPROVED
+
+  # Update custom property
+  hspt quotes update 12345 --prop hs_terms="Net 30"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if title != "" {
+				properties["hs_title"] = title
+			}
+			if status != "" {
+				properties["hs_status"] = status
+			}
+			if expirationDate != "" {
+				properties["hs_expiration_date"] = expirationDate
+			}
+
+			// Parse custom properties
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeQuotes, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Quote %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Quote %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "Quote title")
+	cmd.Flags().StringVar(&status, "status", "", "Quote status (DRAFT, APPROVAL_NOT_NEEDED, etc.)")
+	cmd.Flags().StringVar(&expirationDate, "expiration-date", "", "Quote expiration date (YYYY-MM-DD)")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a quote",
+		Long:  "Archive (soft delete) a quote in HubSpot CRM.",
+		Example: `  # Delete quote
+  hspt quotes delete 12345
+
+  # Delete without confirmation
+  hspt quotes delete 12345 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive quote %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeQuotes, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Quote %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Quote %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}


### PR DESCRIPTION
## Summary
- Add `hspt products` commands (list, get, create, update, delete) for managing HubSpot products
- Add `hspt line-items` commands (list, get, create, update, delete) for managing line items
- Add `hspt quotes` commands (list, get, create, update, delete) for managing quotes

All commands reuse the existing generic CRM client in `api/crm.go` - no new API methods needed.

## Test plan
- [x] Build passes (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [ ] Manual verification with HubSpot API

Closes #18