### PR TITLE
feat: add CRM engagement commands (notes, calls, emails, meetings, tasks)

### DIFF
--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/calls"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/campaigns"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/companies"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/completion"
@@ -12,15 +13,19 @@ import (
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/conversations"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/deals"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/domains"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/emails"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/files"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/forms"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/graphql"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/initcmd"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/lineitems"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/meetings"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/notes"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/owners"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/products"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/quotes"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/tasks"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/tickets"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/workflows"
 	"github.com/open-cli-collective/hubspot-cli/internal/exitcode"
@@ -50,6 +55,13 @@ func run() error {
 	products.Register(rootCmd, opts)
 	lineitems.Register(rootCmd, opts)
 	quotes.Register(rootCmd, opts)
+
+	// CRM engagement commands
+	notes.Register(rootCmd, opts)
+	calls.Register(rootCmd, opts)
+	emails.Register(rootCmd, opts)
+	meetings.Register(rootCmd, opts)
+	tasks.Register(rootCmd, opts)
 
 	// Marketing commands
 	forms.Register(rootCmd, opts)

--- a/internal/cmd/calls/calls.go
+++ b/internal/cmd/calls/calls.go
@@ -1,0 +1,358 @@
+package calls
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for calls
+var DefaultProperties = []string{"hs_call_body", "hs_call_direction", "hs_call_duration", "hs_call_status", "hs_timestamp", "hubspot_owner_id"}
+
+// Register registers the calls command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "calls",
+		Short: "Manage HubSpot calls",
+		Long:  "Commands for listing, viewing, creating, updating, and deleting calls (engagement activities) in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List calls",
+		Long:  "List calls from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 calls
+  hspt calls list
+
+  # List with pagination
+  hspt calls list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeCalls, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No calls found")
+				return nil
+			}
+
+			headers := []string{"ID", "DIRECTION", "DURATION", "STATUS", "TIMESTAMP"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					obj.GetProperty("hs_call_direction"),
+					obj.GetProperty("hs_call_duration"),
+					obj.GetProperty("hs_call_status"),
+					obj.GetProperty("hs_timestamp"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of calls to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a call by ID",
+		Long:  "Retrieve a single call by its ID from HubSpot CRM.",
+		Example: `  # Get call by ID
+  hspt calls get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeCalls, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Call %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Body", obj.GetProperty("hs_call_body")},
+				{"Direction", obj.GetProperty("hs_call_direction")},
+				{"Duration", obj.GetProperty("hs_call_duration")},
+				{"Status", obj.GetProperty("hs_call_status")},
+				{"Timestamp", obj.GetProperty("hs_timestamp")},
+				{"Owner ID", obj.GetProperty("hubspot_owner_id")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var body, direction, duration, status, timestamp, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new call",
+		Long:  "Create a new call record in HubSpot CRM.",
+		Example: `  # Create a call
+  hspt calls create --body "Discussion about project" --direction INBOUND --duration 300
+
+  # Create with status
+  hspt calls create --body "Sales call" --direction OUTBOUND --status COMPLETED`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if body != "" {
+				properties["hs_call_body"] = body
+			}
+			if direction != "" {
+				properties["hs_call_direction"] = direction
+			}
+			if duration != "" {
+				properties["hs_call_duration"] = duration
+			}
+			if status != "" {
+				properties["hs_call_status"] = status
+			}
+			if timestamp != "" {
+				properties["hs_timestamp"] = timestamp
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeCalls, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Call created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Direction", obj.GetProperty("hs_call_direction")},
+				{"Duration", obj.GetProperty("hs_call_duration")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&body, "body", "", "Call notes/body")
+	cmd.Flags().StringVar(&direction, "direction", "", "Call direction (INBOUND, OUTBOUND)")
+	cmd.Flags().StringVar(&duration, "duration", "", "Call duration in seconds")
+	cmd.Flags().StringVar(&status, "status", "", "Call status (COMPLETED, BUSY, NO_ANSWER, etc.)")
+	cmd.Flags().StringVar(&timestamp, "timestamp", "", "Call timestamp (Unix milliseconds)")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "HubSpot owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var body, direction, duration, status, timestamp, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a call",
+		Long:  "Update an existing call in HubSpot CRM.",
+		Example: `  # Update call notes
+  hspt calls update 12345 --body "Updated call notes"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if body != "" {
+				properties["hs_call_body"] = body
+			}
+			if direction != "" {
+				properties["hs_call_direction"] = direction
+			}
+			if duration != "" {
+				properties["hs_call_duration"] = duration
+			}
+			if status != "" {
+				properties["hs_call_status"] = status
+			}
+			if timestamp != "" {
+				properties["hs_timestamp"] = timestamp
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeCalls, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Call %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Call %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&body, "body", "", "Call notes/body")
+	cmd.Flags().StringVar(&direction, "direction", "", "Call direction (INBOUND, OUTBOUND)")
+	cmd.Flags().StringVar(&duration, "duration", "", "Call duration in seconds")
+	cmd.Flags().StringVar(&status, "status", "", "Call status (COMPLETED, BUSY, NO_ANSWER, etc.)")
+	cmd.Flags().StringVar(&timestamp, "timestamp", "", "Call timestamp (Unix milliseconds)")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "HubSpot owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a call",
+		Long:  "Archive (soft delete) a call in HubSpot CRM.",
+		Example: `  # Delete call
+  hspt calls delete 12345
+
+  # Delete without confirmation
+  hspt calls delete 12345 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive call %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeCalls, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Call %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Call %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}

--- a/internal/cmd/emails/emails.go
+++ b/internal/cmd/emails/emails.go
@@ -1,0 +1,365 @@
+package emails
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for emails
+var DefaultProperties = []string{"hs_email_subject", "hs_email_text", "hs_email_direction", "hs_email_status", "hs_timestamp", "hubspot_owner_id"}
+
+// Register registers the emails command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "emails",
+		Short: "Manage HubSpot email engagements",
+		Long:  "Commands for listing, viewing, creating, updating, and deleting email engagements in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List email engagements",
+		Long:  "List email engagements from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 emails
+  hspt emails list
+
+  # List with pagination
+  hspt emails list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeEmails, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No emails found")
+				return nil
+			}
+
+			headers := []string{"ID", "SUBJECT", "DIRECTION", "STATUS", "TIMESTAMP"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					truncate(obj.GetProperty("hs_email_subject"), 40),
+					obj.GetProperty("hs_email_direction"),
+					obj.GetProperty("hs_email_status"),
+					obj.GetProperty("hs_timestamp"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of emails to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get an email by ID",
+		Long:  "Retrieve a single email engagement by its ID from HubSpot CRM.",
+		Example: `  # Get email by ID
+  hspt emails get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeEmails, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Email %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Subject", obj.GetProperty("hs_email_subject")},
+				{"Text", truncate(obj.GetProperty("hs_email_text"), 100)},
+				{"Direction", obj.GetProperty("hs_email_direction")},
+				{"Status", obj.GetProperty("hs_email_status")},
+				{"Timestamp", obj.GetProperty("hs_timestamp")},
+				{"Owner ID", obj.GetProperty("hubspot_owner_id")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var subject, text, direction, status, timestamp, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new email engagement",
+		Long:  "Create a new email engagement record in HubSpot CRM.",
+		Example: `  # Create an email record
+  hspt emails create --subject "Follow-up" --text "Email body content" --direction EMAIL
+
+  # Create with status
+  hspt emails create --subject "Proposal" --direction EMAIL --status SENT`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if subject != "" {
+				properties["hs_email_subject"] = subject
+			}
+			if text != "" {
+				properties["hs_email_text"] = text
+			}
+			if direction != "" {
+				properties["hs_email_direction"] = direction
+			}
+			if status != "" {
+				properties["hs_email_status"] = status
+			}
+			if timestamp != "" {
+				properties["hs_timestamp"] = timestamp
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeEmails, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Email created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Subject", obj.GetProperty("hs_email_subject")},
+				{"Direction", obj.GetProperty("hs_email_direction")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "Email subject")
+	cmd.Flags().StringVar(&text, "text", "", "Email body text")
+	cmd.Flags().StringVar(&direction, "direction", "", "Email direction (EMAIL, INCOMING_EMAIL, FORWARDED_EMAIL)")
+	cmd.Flags().StringVar(&status, "status", "", "Email status (SENT, SCHEDULED, BOUNCED, etc.)")
+	cmd.Flags().StringVar(&timestamp, "timestamp", "", "Email timestamp (Unix milliseconds)")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "HubSpot owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var subject, text, direction, status, timestamp, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update an email engagement",
+		Long:  "Update an existing email engagement in HubSpot CRM.",
+		Example: `  # Update email subject
+  hspt emails update 12345 --subject "Updated Subject"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if subject != "" {
+				properties["hs_email_subject"] = subject
+			}
+			if text != "" {
+				properties["hs_email_text"] = text
+			}
+			if direction != "" {
+				properties["hs_email_direction"] = direction
+			}
+			if status != "" {
+				properties["hs_email_status"] = status
+			}
+			if timestamp != "" {
+				properties["hs_timestamp"] = timestamp
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeEmails, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Email %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Email %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "Email subject")
+	cmd.Flags().StringVar(&text, "text", "", "Email body text")
+	cmd.Flags().StringVar(&direction, "direction", "", "Email direction (EMAIL, INCOMING_EMAIL, FORWARDED_EMAIL)")
+	cmd.Flags().StringVar(&status, "status", "", "Email status (SENT, SCHEDULED, BOUNCED, etc.)")
+	cmd.Flags().StringVar(&timestamp, "timestamp", "", "Email timestamp (Unix milliseconds)")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "HubSpot owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete an email engagement",
+		Long:  "Archive (soft delete) an email engagement in HubSpot CRM.",
+		Example: `  # Delete email
+  hspt emails delete 12345
+
+  # Delete without confirmation
+  hspt emails delete 12345 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive email %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeEmails, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Email %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Email %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/cmd/meetings/meetings.go
+++ b/internal/cmd/meetings/meetings.go
@@ -1,0 +1,365 @@
+package meetings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for meetings
+var DefaultProperties = []string{"hs_meeting_title", "hs_meeting_body", "hs_meeting_start_time", "hs_meeting_end_time", "hs_meeting_outcome", "hubspot_owner_id"}
+
+// Register registers the meetings command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "meetings",
+		Short: "Manage HubSpot meetings",
+		Long:  "Commands for listing, viewing, creating, updating, and deleting meetings (engagement activities) in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List meetings",
+		Long:  "List meetings from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 meetings
+  hspt meetings list
+
+  # List with pagination
+  hspt meetings list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeMeetings, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No meetings found")
+				return nil
+			}
+
+			headers := []string{"ID", "TITLE", "START TIME", "END TIME", "OUTCOME"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					truncate(obj.GetProperty("hs_meeting_title"), 40),
+					obj.GetProperty("hs_meeting_start_time"),
+					obj.GetProperty("hs_meeting_end_time"),
+					obj.GetProperty("hs_meeting_outcome"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of meetings to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a meeting by ID",
+		Long:  "Retrieve a single meeting by its ID from HubSpot CRM.",
+		Example: `  # Get meeting by ID
+  hspt meetings get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeMeetings, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Meeting %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Title", obj.GetProperty("hs_meeting_title")},
+				{"Body", truncate(obj.GetProperty("hs_meeting_body"), 100)},
+				{"Start Time", obj.GetProperty("hs_meeting_start_time")},
+				{"End Time", obj.GetProperty("hs_meeting_end_time")},
+				{"Outcome", obj.GetProperty("hs_meeting_outcome")},
+				{"Owner ID", obj.GetProperty("hubspot_owner_id")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var title, body, startTime, endTime, outcome, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new meeting",
+		Long:  "Create a new meeting record in HubSpot CRM.",
+		Example: `  # Create a meeting
+  hspt meetings create --title "Sales Demo" --start-time 1704067200000 --end-time 1704070800000
+
+  # Create with outcome
+  hspt meetings create --title "Discovery Call" --outcome SCHEDULED`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if title != "" {
+				properties["hs_meeting_title"] = title
+			}
+			if body != "" {
+				properties["hs_meeting_body"] = body
+			}
+			if startTime != "" {
+				properties["hs_meeting_start_time"] = startTime
+			}
+			if endTime != "" {
+				properties["hs_meeting_end_time"] = endTime
+			}
+			if outcome != "" {
+				properties["hs_meeting_outcome"] = outcome
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeMeetings, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Meeting created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Title", obj.GetProperty("hs_meeting_title")},
+				{"Start Time", obj.GetProperty("hs_meeting_start_time")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "Meeting title")
+	cmd.Flags().StringVar(&body, "body", "", "Meeting description/notes")
+	cmd.Flags().StringVar(&startTime, "start-time", "", "Meeting start time (Unix milliseconds)")
+	cmd.Flags().StringVar(&endTime, "end-time", "", "Meeting end time (Unix milliseconds)")
+	cmd.Flags().StringVar(&outcome, "outcome", "", "Meeting outcome (SCHEDULED, COMPLETED, RESCHEDULED, etc.)")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "HubSpot owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var title, body, startTime, endTime, outcome, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a meeting",
+		Long:  "Update an existing meeting in HubSpot CRM.",
+		Example: `  # Update meeting outcome
+  hspt meetings update 12345 --outcome COMPLETED`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if title != "" {
+				properties["hs_meeting_title"] = title
+			}
+			if body != "" {
+				properties["hs_meeting_body"] = body
+			}
+			if startTime != "" {
+				properties["hs_meeting_start_time"] = startTime
+			}
+			if endTime != "" {
+				properties["hs_meeting_end_time"] = endTime
+			}
+			if outcome != "" {
+				properties["hs_meeting_outcome"] = outcome
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeMeetings, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Meeting %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Meeting %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "Meeting title")
+	cmd.Flags().StringVar(&body, "body", "", "Meeting description/notes")
+	cmd.Flags().StringVar(&startTime, "start-time", "", "Meeting start time (Unix milliseconds)")
+	cmd.Flags().StringVar(&endTime, "end-time", "", "Meeting end time (Unix milliseconds)")
+	cmd.Flags().StringVar(&outcome, "outcome", "", "Meeting outcome (SCHEDULED, COMPLETED, RESCHEDULED, etc.)")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "HubSpot owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a meeting",
+		Long:  "Archive (soft delete) a meeting in HubSpot CRM.",
+		Example: `  # Delete meeting
+  hspt meetings delete 12345
+
+  # Delete without confirmation
+  hspt meetings delete 12345 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive meeting %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeMeetings, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Meeting %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Meeting %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/cmd/notes/notes.go
+++ b/internal/cmd/notes/notes.go
@@ -1,0 +1,336 @@
+package notes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for notes
+var DefaultProperties = []string{"hs_note_body", "hs_timestamp", "hubspot_owner_id"}
+
+// Register registers the notes command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "notes",
+		Short: "Manage HubSpot notes",
+		Long:  "Commands for listing, viewing, creating, updating, and deleting notes (engagement activities) in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List notes",
+		Long:  "List notes from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 notes
+  hspt notes list
+
+  # List with pagination
+  hspt notes list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeNotes, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No notes found")
+				return nil
+			}
+
+			headers := []string{"ID", "BODY", "TIMESTAMP", "OWNER ID"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					truncate(obj.GetProperty("hs_note_body"), 50),
+					obj.GetProperty("hs_timestamp"),
+					obj.GetProperty("hubspot_owner_id"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of notes to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a note by ID",
+		Long:  "Retrieve a single note by its ID from HubSpot CRM.",
+		Example: `  # Get note by ID
+  hspt notes get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeNotes, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Note %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Body", obj.GetProperty("hs_note_body")},
+				{"Timestamp", obj.GetProperty("hs_timestamp")},
+				{"Owner ID", obj.GetProperty("hubspot_owner_id")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var body, timestamp, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new note",
+		Long:  "Create a new note in HubSpot CRM.",
+		Example: `  # Create a note
+  hspt notes create --body "Meeting notes from today's call"
+
+  # Create with owner
+  hspt notes create --body "Follow-up required" --owner-id 12345`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if body != "" {
+				properties["hs_note_body"] = body
+			}
+			if timestamp != "" {
+				properties["hs_timestamp"] = timestamp
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required (--body is recommended)")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeNotes, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Note created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Body", truncate(obj.GetProperty("hs_note_body"), 80)},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&body, "body", "", "Note body content")
+	cmd.Flags().StringVar(&timestamp, "timestamp", "", "Note timestamp (Unix milliseconds)")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "HubSpot owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var body, timestamp, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a note",
+		Long:  "Update an existing note in HubSpot CRM.",
+		Example: `  # Update note body
+  hspt notes update 12345 --body "Updated meeting notes"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if body != "" {
+				properties["hs_note_body"] = body
+			}
+			if timestamp != "" {
+				properties["hs_timestamp"] = timestamp
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeNotes, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Note %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Note %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&body, "body", "", "Note body content")
+	cmd.Flags().StringVar(&timestamp, "timestamp", "", "Note timestamp (Unix milliseconds)")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "HubSpot owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a note",
+		Long:  "Archive (soft delete) a note in HubSpot CRM.",
+		Example: `  # Delete note
+  hspt notes delete 12345
+
+  # Delete without confirmation
+  hspt notes delete 12345 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive note %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeNotes, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Note %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Note %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/cmd/tasks/tasks.go
+++ b/internal/cmd/tasks/tasks.go
@@ -1,0 +1,369 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// DefaultProperties are the default properties to fetch for tasks
+var DefaultProperties = []string{"hs_task_subject", "hs_task_body", "hs_task_status", "hs_task_priority", "hs_timestamp", "hubspot_owner_id"}
+
+// Register registers the tasks command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "tasks",
+		Short: "Manage HubSpot tasks",
+		Long:  "Commands for listing, viewing, creating, updating, and deleting tasks (engagement activities) in HubSpot CRM.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tasks",
+		Long:  "List tasks from HubSpot CRM with pagination support.",
+		Example: `  # List first 10 tasks
+  hspt tasks list
+
+  # List with pagination
+  hspt tasks list --limit 50 --after abc123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			result, err := client.ListObjects(api.ObjectTypeTasks, api.ListOptions{
+				Limit:      limit,
+				After:      after,
+				Properties: properties,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No tasks found")
+				return nil
+			}
+
+			headers := []string{"ID", "SUBJECT", "STATUS", "PRIORITY", "TIMESTAMP"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, obj := range result.Results {
+				rows = append(rows, []string{
+					obj.ID,
+					truncate(obj.GetProperty("hs_task_subject"), 40),
+					obj.GetProperty("hs_task_status"),
+					obj.GetProperty("hs_task_priority"),
+					obj.GetProperty("hs_timestamp"),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of tasks to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var properties []string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a task by ID",
+		Long:  "Retrieve a single task by its ID from HubSpot CRM.",
+		Example: `  # Get task by ID
+  hspt tasks get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if len(properties) == 0 {
+				properties = DefaultProperties
+			}
+
+			obj, err := client.GetObject(api.ObjectTypeTasks, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Task %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Subject", obj.GetProperty("hs_task_subject")},
+				{"Body", truncate(obj.GetProperty("hs_task_body"), 100)},
+				{"Status", obj.GetProperty("hs_task_status")},
+				{"Priority", obj.GetProperty("hs_task_priority")},
+				{"Timestamp", obj.GetProperty("hs_timestamp")},
+				{"Owner ID", obj.GetProperty("hubspot_owner_id")},
+				{"Created", obj.CreatedAt},
+				{"Updated", obj.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&properties, "properties", nil, "Properties to include (comma-separated)")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var subject, body, status, priority, timestamp, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new task",
+		Long:  "Create a new task in HubSpot CRM.",
+		Example: `  # Create a task
+  hspt tasks create --subject "Follow up with client" --status NOT_STARTED --priority HIGH
+
+  # Create with body
+  hspt tasks create --subject "Review proposal" --body "Check pricing section"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if subject != "" {
+				properties["hs_task_subject"] = subject
+			}
+			if body != "" {
+				properties["hs_task_body"] = body
+			}
+			if status != "" {
+				properties["hs_task_status"] = status
+			}
+			if priority != "" {
+				properties["hs_task_priority"] = priority
+			}
+			if timestamp != "" {
+				properties["hs_timestamp"] = timestamp
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property is required (--subject is recommended)")
+			}
+
+			obj, err := client.CreateObject(api.ObjectTypeTasks, properties)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Task created with ID: %s", obj.ID)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", obj.ID},
+				{"Subject", obj.GetProperty("hs_task_subject")},
+				{"Status", obj.GetProperty("hs_task_status")},
+				{"Priority", obj.GetProperty("hs_task_priority")},
+			}
+
+			return v.Render(headers, rows, obj)
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "Task subject")
+	cmd.Flags().StringVar(&body, "body", "", "Task body/description")
+	cmd.Flags().StringVar(&status, "status", "", "Task status (NOT_STARTED, IN_PROGRESS, COMPLETED, etc.)")
+	cmd.Flags().StringVar(&priority, "priority", "", "Task priority (LOW, MEDIUM, HIGH)")
+	cmd.Flags().StringVar(&timestamp, "timestamp", "", "Task due date (Unix milliseconds)")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "HubSpot owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var subject, body, status, priority, timestamp, ownerID string
+	var props []string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a task",
+		Long:  "Update an existing task in HubSpot CRM.",
+		Example: `  # Update task status
+  hspt tasks update 12345 --status COMPLETED
+
+  # Update task priority
+  hspt tasks update 12345 --priority HIGH`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			properties := make(map[string]interface{})
+			if subject != "" {
+				properties["hs_task_subject"] = subject
+			}
+			if body != "" {
+				properties["hs_task_body"] = body
+			}
+			if status != "" {
+				properties["hs_task_status"] = status
+			}
+			if priority != "" {
+				properties["hs_task_priority"] = priority
+			}
+			if timestamp != "" {
+				properties["hs_timestamp"] = timestamp
+			}
+			if ownerID != "" {
+				properties["hubspot_owner_id"] = ownerID
+			}
+
+			for _, p := range props {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) == 2 {
+					properties[parts[0]] = parts[1]
+				}
+			}
+
+			if len(properties) == 0 {
+				return fmt.Errorf("at least one property to update is required")
+			}
+
+			obj, err := client.UpdateObject(api.ObjectTypeTasks, id, properties)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Task %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Task %s updated", obj.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "Task subject")
+	cmd.Flags().StringVar(&body, "body", "", "Task body/description")
+	cmd.Flags().StringVar(&status, "status", "", "Task status (NOT_STARTED, IN_PROGRESS, COMPLETED, etc.)")
+	cmd.Flags().StringVar(&priority, "priority", "", "Task priority (LOW, MEDIUM, HIGH)")
+	cmd.Flags().StringVar(&timestamp, "timestamp", "", "Task due date (Unix milliseconds)")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "HubSpot owner ID")
+	cmd.Flags().StringArrayVar(&props, "prop", nil, "Custom property in key=value format")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a task",
+		Long:  "Archive (soft delete) a task in HubSpot CRM.",
+		Example: `  # Delete task
+  hspt tasks delete 12345
+
+  # Delete without confirmation
+  hspt tasks delete 12345 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if !force {
+				v.Warning("This will archive task %s. Use --force to confirm.", id)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteObject(api.ObjectTypeTasks, id); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Task %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Task %s archived", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}


### PR DESCRIPTION
## Summary
- Add `hspt notes` commands for managing note engagements
- Add `hspt calls` commands for managing call engagements  
- Add `hspt emails` commands for managing email engagements
- Add `hspt meetings` commands for managing meeting engagements
- Add `hspt tasks` commands for managing task engagements

All commands support list, get, create, update, delete operations and reuse the existing generic CRM client.

## Test plan
- [x] Build passes (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [ ] Manual verification with HubSpot API

Closes #19