### PR TITLE
feat: add CRM infrastructure commands (associations, properties, pipelines)

### DIFF
--- a/api/associations.go
+++ b/api/associations.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Association represents a HubSpot association between objects
+type Association struct {
+	ToObjectID       string            `json:"toObjectId"`
+	AssociationTypes []AssociationType `json:"associationTypes"`
+}
+
+// AssociationType describes the type of association
+type AssociationType struct {
+	Category string `json:"category"`
+	TypeID   int    `json:"typeId"`
+	Label    string `json:"label,omitempty"`
+}
+
+// AssociationList represents a paginated list of associations
+type AssociationList struct {
+	Results []Association `json:"results"`
+	Paging  *Paging       `json:"paging,omitempty"`
+}
+
+// ListAssociations retrieves associations from one object to another type
+// Uses CRM v4 associations API
+func (c *Client) ListAssociations(fromType ObjectType, fromID string, toType ObjectType, opts ListOptions) (*AssociationList, error) {
+	if fromID == "" {
+		return nil, fmt.Errorf("from object ID is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v4/objects/%s/%s/associations/%s", c.BaseURL, fromType, fromID, toType)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result AssociationList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CreateAssociation creates an association between two objects
+// Uses CRM v4 associations API
+func (c *Client) CreateAssociation(fromType ObjectType, fromID string, toType ObjectType, toID string, associationTypeID int) error {
+	if fromID == "" {
+		return fmt.Errorf("from object ID is required")
+	}
+	if toID == "" {
+		return fmt.Errorf("to object ID is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v4/objects/%s/%s/associations/%s/%s", c.BaseURL, fromType, fromID, toType, toID)
+
+	payload := []map[string]interface{}{
+		{
+			"associationCategory": "HUBSPOT_DEFINED",
+			"associationTypeId":   associationTypeID,
+		},
+	}
+
+	_, err := c.put(url, payload)
+	return err
+}
+
+// DeleteAssociation removes an association between two objects
+// Uses CRM v4 associations API
+func (c *Client) DeleteAssociation(fromType ObjectType, fromID string, toType ObjectType, toID string) error {
+	if fromID == "" {
+		return fmt.Errorf("from object ID is required")
+	}
+	if toID == "" {
+		return fmt.Errorf("to object ID is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v4/objects/%s/%s/associations/%s/%s", c.BaseURL, fromType, fromID, toType, toID)
+
+	_, err := c.delete(url)
+	return err
+}

--- a/api/client.go
+++ b/api/client.go
@@ -111,6 +111,11 @@ func (c *Client) patch(urlStr string, body interface{}) ([]byte, error) {
 	return c.doRequest(http.MethodPatch, urlStr, body)
 }
 
+// put performs a PUT request
+func (c *Client) put(urlStr string, body interface{}) ([]byte, error) {
+	return c.doRequest(http.MethodPut, urlStr, body)
+}
+
 // delete performs a DELETE request
 func (c *Client) delete(urlStr string) ([]byte, error) {
 	return c.doRequest(http.MethodDelete, urlStr, nil)

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Pipeline represents a HubSpot pipeline
+type Pipeline struct {
+	ID           string          `json:"id"`
+	Label        string          `json:"label"`
+	DisplayOrder int             `json:"displayOrder"`
+	Archived     bool            `json:"archived,omitempty"`
+	Stages       []PipelineStage `json:"stages,omitempty"`
+	CreatedAt    string          `json:"createdAt,omitempty"`
+	UpdatedAt    string          `json:"updatedAt,omitempty"`
+	ArchivedAt   string          `json:"archivedAt,omitempty"`
+}
+
+// PipelineStage represents a stage within a pipeline
+type PipelineStage struct {
+	ID           string                 `json:"id"`
+	Label        string                 `json:"label"`
+	DisplayOrder int                    `json:"displayOrder"`
+	Metadata     map[string]interface{} `json:"metadata,omitempty"`
+	Archived     bool                   `json:"archived,omitempty"`
+	CreatedAt    string                 `json:"createdAt,omitempty"`
+	UpdatedAt    string                 `json:"updatedAt,omitempty"`
+	ArchivedAt   string                 `json:"archivedAt,omitempty"`
+}
+
+// PipelineList represents a list of pipelines
+type PipelineList struct {
+	Results []Pipeline `json:"results"`
+}
+
+// ListPipelines lists all pipelines for an object type
+func (c *Client) ListPipelines(objectType ObjectType) (*PipelineList, error) {
+	url := fmt.Sprintf("%s/crm/v3/pipelines/%s", c.BaseURL, objectType)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result PipelineList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetPipeline retrieves a specific pipeline by ID
+func (c *Client) GetPipeline(objectType ObjectType, pipelineID string) (*Pipeline, error) {
+	if pipelineID == "" {
+		return nil, fmt.Errorf("pipeline ID is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v3/pipelines/%s/%s", c.BaseURL, objectType, pipelineID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Pipeline
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetPipelineStages retrieves all stages for a pipeline
+func (c *Client) GetPipelineStages(objectType ObjectType, pipelineID string) ([]PipelineStage, error) {
+	if pipelineID == "" {
+		return nil, fmt.Errorf("pipeline ID is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v3/pipelines/%s/%s/stages", c.BaseURL, objectType, pipelineID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Results []PipelineStage `json:"results"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return result.Results, nil
+}

--- a/api/properties.go
+++ b/api/properties.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Property represents a HubSpot property definition
+type Property struct {
+	Name                 string            `json:"name"`
+	Label                string            `json:"label"`
+	Type                 string            `json:"type"`
+	FieldType            string            `json:"fieldType"`
+	Description          string            `json:"description,omitempty"`
+	GroupName            string            `json:"groupName"`
+	Options              []PropertyOption  `json:"options,omitempty"`
+	DisplayOrder         int               `json:"displayOrder,omitempty"`
+	Calculated           bool              `json:"calculated,omitempty"`
+	ExternalOptions      bool              `json:"externalOptions,omitempty"`
+	HasUniqueValue       bool              `json:"hasUniqueValue,omitempty"`
+	Hidden               bool              `json:"hidden,omitempty"`
+	HubspotDefined       bool              `json:"hubspotDefined,omitempty"`
+	ModificationMetadata *ModificationMeta `json:"modificationMetadata,omitempty"`
+	FormField            bool              `json:"formField,omitempty"`
+	CreatedAt            string            `json:"createdAt,omitempty"`
+	UpdatedAt            string            `json:"updatedAt,omitempty"`
+	ArchivedAt           string            `json:"archivedAt,omitempty"`
+	Archived             bool              `json:"archived,omitempty"`
+}
+
+// PropertyOption represents an option for enumeration properties
+type PropertyOption struct {
+	Label        string `json:"label"`
+	Value        string `json:"value"`
+	Description  string `json:"description,omitempty"`
+	DisplayOrder int    `json:"displayOrder,omitempty"`
+	Hidden       bool   `json:"hidden,omitempty"`
+}
+
+// ModificationMeta contains metadata about property modifications
+type ModificationMeta struct {
+	Archivable         bool `json:"archivable"`
+	ReadOnlyValue      bool `json:"readOnlyValue"`
+	ReadOnlyDefinition bool `json:"readOnlyDefinition"`
+}
+
+// PropertyList represents a list of properties
+type PropertyList struct {
+	Results []Property `json:"results"`
+}
+
+// CreatePropertyRequest represents a request to create a property
+type CreatePropertyRequest struct {
+	Name           string           `json:"name"`
+	Label          string           `json:"label"`
+	Type           string           `json:"type"`
+	FieldType      string           `json:"fieldType"`
+	GroupName      string           `json:"groupName"`
+	Description    string           `json:"description,omitempty"`
+	Options        []PropertyOption `json:"options,omitempty"`
+	DisplayOrder   int              `json:"displayOrder,omitempty"`
+	HasUniqueValue bool             `json:"hasUniqueValue,omitempty"`
+	Hidden         bool             `json:"hidden,omitempty"`
+	FormField      bool             `json:"formField,omitempty"`
+}
+
+// ListProperties lists all properties for an object type
+func (c *Client) ListProperties(objectType ObjectType) (*PropertyList, error) {
+	url := fmt.Sprintf("%s/crm/v3/properties/%s", c.BaseURL, objectType)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result PropertyList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetProperty retrieves a specific property by name
+func (c *Client) GetProperty(objectType ObjectType, propertyName string) (*Property, error) {
+	if propertyName == "" {
+		return nil, fmt.Errorf("property name is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v3/properties/%s/%s", c.BaseURL, objectType, propertyName)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Property
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CreateProperty creates a new property for an object type
+func (c *Client) CreateProperty(objectType ObjectType, req CreatePropertyRequest) (*Property, error) {
+	url := fmt.Sprintf("%s/crm/v3/properties/%s", c.BaseURL, objectType)
+
+	body, err := c.post(url, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Property
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteProperty archives (soft deletes) a property
+func (c *Client) DeleteProperty(objectType ObjectType, propertyName string) error {
+	if propertyName == "" {
+		return fmt.Errorf("property name is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v3/properties/%s/%s", c.BaseURL, objectType, propertyName)
+
+	_, err := c.delete(url)
+	return err
+}

--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/associations"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/calls"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/campaigns"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/companies"
@@ -22,7 +23,9 @@ import (
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/meetings"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/notes"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/owners"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/pipelines"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/products"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/properties"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/quotes"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/tasks"
@@ -62,6 +65,11 @@ func run() error {
 	emails.Register(rootCmd, opts)
 	meetings.Register(rootCmd, opts)
 	tasks.Register(rootCmd, opts)
+
+	// CRM infrastructure commands
+	associations.Register(rootCmd, opts)
+	properties.Register(rootCmd, opts)
+	pipelines.Register(rootCmd, opts)
 
 	// Marketing commands
 	forms.Register(rootCmd, opts)

--- a/internal/cmd/associations/associations.go
+++ b/internal/cmd/associations/associations.go
@@ -1,0 +1,208 @@
+package associations
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the associations command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:     "associations",
+		Aliases: []string{"assoc"},
+		Short:   "Manage HubSpot associations",
+		Long:    "Commands for listing, creating, and deleting associations between CRM objects.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var fromType, toType, fromID string
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List associations",
+		Long:  "List associations from one object to another type.",
+		Example: `  # List companies associated with a contact
+  hspt associations list --from-type contacts --from-id 123 --to-type companies
+
+  # List deals associated with a company
+  hspt associations list --from-type companies --from-id 456 --to-type deals`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if fromType == "" || toType == "" || fromID == "" {
+				return fmt.Errorf("--from-type, --from-id, and --to-type are required")
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListAssociations(
+				api.ObjectType(fromType),
+				fromID,
+				api.ObjectType(toType),
+				api.ListOptions{
+					Limit: limit,
+					After: after,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No associations found")
+				return nil
+			}
+
+			headers := []string{"TO OBJECT ID", "ASSOCIATION TYPE", "CATEGORY"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, assoc := range result.Results {
+				for _, at := range assoc.AssociationTypes {
+					label := at.Label
+					if label == "" {
+						label = fmt.Sprintf("Type %d", at.TypeID)
+					}
+					rows = append(rows, []string{
+						assoc.ToObjectID,
+						label,
+						at.Category,
+					})
+				}
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fromType, "from-type", "", "Source object type (contacts, companies, deals, etc.)")
+	cmd.Flags().StringVar(&fromID, "from-id", "", "Source object ID")
+	cmd.Flags().StringVar(&toType, "to-type", "", "Target object type (contacts, companies, deals, etc.)")
+	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of associations to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var fromType, toType, fromID, toID string
+	var typeID int
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an association",
+		Long:  "Create an association between two CRM objects.",
+		Example: `  # Associate a contact with a company (default association type)
+  hspt associations create --from-type contacts --from-id 123 --to-type companies --to-id 456
+
+  # Associate with a specific type ID
+  hspt associations create --from-type contacts --from-id 123 --to-type companies --to-id 456 --type-id 1`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if fromType == "" || toType == "" || fromID == "" || toID == "" {
+				return fmt.Errorf("--from-type, --from-id, --to-type, and --to-id are required")
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			err = client.CreateAssociation(
+				api.ObjectType(fromType),
+				fromID,
+				api.ObjectType(toType),
+				toID,
+				typeID,
+			)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Association created between %s %s and %s %s", fromType, fromID, toType, toID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fromType, "from-type", "", "Source object type (contacts, companies, deals, etc.)")
+	cmd.Flags().StringVar(&fromID, "from-id", "", "Source object ID")
+	cmd.Flags().StringVar(&toType, "to-type", "", "Target object type (contacts, companies, deals, etc.)")
+	cmd.Flags().StringVar(&toID, "to-id", "", "Target object ID")
+	cmd.Flags().IntVar(&typeID, "type-id", 1, "Association type ID (default: 1 for standard association)")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var fromType, toType, fromID, toID string
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete an association",
+		Long:  "Delete an association between two CRM objects.",
+		Example: `  # Delete association between contact and company
+  hspt associations delete --from-type contacts --from-id 123 --to-type companies --to-id 456 --force`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if fromType == "" || toType == "" || fromID == "" || toID == "" {
+				return fmt.Errorf("--from-type, --from-id, --to-type, and --to-id are required")
+			}
+
+			if !force {
+				v.Warning("This will delete the association between %s %s and %s %s. Use --force to confirm.", fromType, fromID, toType, toID)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			err = client.DeleteAssociation(
+				api.ObjectType(fromType),
+				fromID,
+				api.ObjectType(toType),
+				toID,
+			)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Association deleted between %s %s and %s %s", fromType, fromID, toType, toID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fromType, "from-type", "", "Source object type (contacts, companies, deals, etc.)")
+	cmd.Flags().StringVar(&fromID, "from-id", "", "Source object ID")
+	cmd.Flags().StringVar(&toType, "to-type", "", "Target object type (contacts, companies, deals, etc.)")
+	cmd.Flags().StringVar(&toID, "to-id", "", "Target object ID")
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}

--- a/internal/cmd/pipelines/pipelines.go
+++ b/internal/cmd/pipelines/pipelines.go
@@ -1,0 +1,202 @@
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the pipelines command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "pipelines",
+		Short: "Manage HubSpot pipelines",
+		Long:  "Commands for listing and viewing pipelines and their stages.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newStagesCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var objectType string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List pipelines",
+		Long:  "List all pipelines for an object type.",
+		Example: `  # List deal pipelines
+  hspt pipelines list --object-type deals
+
+  # List ticket pipelines
+  hspt pipelines list --object-type tickets`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if objectType == "" {
+				return fmt.Errorf("--object-type is required (deals or tickets)")
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListPipelines(api.ObjectType(objectType))
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No pipelines found")
+				return nil
+			}
+
+			headers := []string{"ID", "LABEL", "DISPLAY ORDER", "STAGES"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, pipeline := range result.Results {
+				rows = append(rows, []string{
+					pipeline.ID,
+					pipeline.Label,
+					fmt.Sprintf("%d", pipeline.DisplayOrder),
+					fmt.Sprintf("%d", len(pipeline.Stages)),
+				})
+			}
+
+			return v.Render(headers, rows, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&objectType, "object-type", "", "Object type (deals or tickets)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var objectType, pipelineID string
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get a pipeline",
+		Long:  "Get details of a specific pipeline.",
+		Example: `  # Get a deal pipeline
+  hspt pipelines get --object-type deals --id default
+
+  # Get a ticket pipeline
+  hspt pipelines get --object-type tickets --id 12345`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if objectType == "" || pipelineID == "" {
+				return fmt.Errorf("--object-type and --id are required")
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			pipeline, err := client.GetPipeline(api.ObjectType(objectType), pipelineID)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Pipeline %s not found for %s", pipelineID, objectType)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", pipeline.ID},
+				{"Label", pipeline.Label},
+				{"Display Order", fmt.Sprintf("%d", pipeline.DisplayOrder)},
+				{"Archived", formatBool(pipeline.Archived)},
+				{"Created", pipeline.CreatedAt},
+				{"Updated", pipeline.UpdatedAt},
+			}
+
+			if len(pipeline.Stages) > 0 {
+				rows = append(rows, []string{"Stages", fmt.Sprintf("%d stages", len(pipeline.Stages))})
+			}
+
+			return v.Render(headers, rows, pipeline)
+		},
+	}
+
+	cmd.Flags().StringVar(&objectType, "object-type", "", "Object type (deals or tickets)")
+	cmd.Flags().StringVar(&pipelineID, "id", "", "Pipeline ID")
+
+	return cmd
+}
+
+func newStagesCmd(opts *root.Options) *cobra.Command {
+	var objectType, pipelineID string
+
+	cmd := &cobra.Command{
+		Use:   "stages",
+		Short: "List pipeline stages",
+		Long:  "List all stages for a specific pipeline.",
+		Example: `  # List stages for default deal pipeline
+  hspt pipelines stages --object-type deals --id default
+
+  # List stages for a ticket pipeline
+  hspt pipelines stages --object-type tickets --id 12345`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if objectType == "" || pipelineID == "" {
+				return fmt.Errorf("--object-type and --id are required")
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			stages, err := client.GetPipelineStages(api.ObjectType(objectType), pipelineID)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Pipeline %s not found for %s", pipelineID, objectType)
+					return nil
+				}
+				return err
+			}
+
+			if len(stages) == 0 {
+				v.Info("No stages found")
+				return nil
+			}
+
+			headers := []string{"ID", "LABEL", "DISPLAY ORDER", "ARCHIVED"}
+			rows := make([][]string, 0, len(stages))
+			for _, stage := range stages {
+				rows = append(rows, []string{
+					stage.ID,
+					stage.Label,
+					fmt.Sprintf("%d", stage.DisplayOrder),
+					formatBool(stage.Archived),
+				})
+			}
+
+			return v.Render(headers, rows, stages)
+		},
+	}
+
+	cmd.Flags().StringVar(&objectType, "object-type", "", "Object type (deals or tickets)")
+	cmd.Flags().StringVar(&pipelineID, "id", "", "Pipeline ID")
+
+	return cmd
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}

--- a/internal/cmd/properties/properties.go
+++ b/internal/cmd/properties/properties.go
@@ -1,0 +1,271 @@
+package properties
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the properties command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:     "properties",
+		Aliases: []string{"props"},
+		Short:   "Manage HubSpot properties",
+		Long:    "Commands for listing, viewing, creating, and deleting object properties.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var objectType string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List properties",
+		Long:  "List all properties for an object type.",
+		Example: `  # List contact properties
+  hspt properties list --object-type contacts
+
+  # List deal properties
+  hspt properties list --object-type deals`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if objectType == "" {
+				return fmt.Errorf("--object-type is required")
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListProperties(api.ObjectType(objectType))
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No properties found")
+				return nil
+			}
+
+			headers := []string{"NAME", "LABEL", "TYPE", "FIELD TYPE", "GROUP"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, prop := range result.Results {
+				rows = append(rows, []string{
+					prop.Name,
+					prop.Label,
+					prop.Type,
+					prop.FieldType,
+					prop.GroupName,
+				})
+			}
+
+			v.Info("Found %d properties for %s", len(result.Results), objectType)
+			return v.Render(headers, rows, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&objectType, "object-type", "", "Object type (contacts, companies, deals, tickets, etc.)")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var objectType, name string
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get a property",
+		Long:  "Get details of a specific property.",
+		Example: `  # Get the email property for contacts
+  hspt properties get --object-type contacts --name email
+
+  # Get a custom property
+  hspt properties get --object-type contacts --name my_custom_field`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if objectType == "" || name == "" {
+				return fmt.Errorf("--object-type and --name are required")
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			prop, err := client.GetProperty(api.ObjectType(objectType), name)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Property %s not found for %s", name, objectType)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"Name", prop.Name},
+				{"Label", prop.Label},
+				{"Type", prop.Type},
+				{"Field Type", prop.FieldType},
+				{"Group", prop.GroupName},
+				{"Description", prop.Description},
+				{"HubSpot Defined", formatBool(prop.HubspotDefined)},
+				{"Calculated", formatBool(prop.Calculated)},
+				{"Hidden", formatBool(prop.Hidden)},
+				{"Created", prop.CreatedAt},
+				{"Updated", prop.UpdatedAt},
+			}
+
+			if len(prop.Options) > 0 {
+				rows = append(rows, []string{"Options", fmt.Sprintf("%d options", len(prop.Options))})
+			}
+
+			return v.Render(headers, rows, prop)
+		},
+	}
+
+	cmd.Flags().StringVar(&objectType, "object-type", "", "Object type (contacts, companies, deals, tickets, etc.)")
+	cmd.Flags().StringVar(&name, "name", "", "Property name")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var objectType, name, label, propType, fieldType, groupName, description string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a property",
+		Long:  "Create a new custom property for an object type.",
+		Example: `  # Create a text property
+  hspt properties create --object-type contacts --name my_field --label "My Field" --type string --field-type text
+
+  # Create a number property
+  hspt properties create --object-type deals --name custom_amount --label "Custom Amount" --type number --field-type number`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if objectType == "" || name == "" || label == "" || propType == "" || fieldType == "" {
+				return fmt.Errorf("--object-type, --name, --label, --type, and --field-type are required")
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			req := api.CreatePropertyRequest{
+				Name:      name,
+				Label:     label,
+				Type:      propType,
+				FieldType: fieldType,
+				GroupName: groupName,
+			}
+
+			if description != "" {
+				req.Description = description
+			}
+
+			if groupName == "" {
+				// Default group name based on object type
+				req.GroupName = objectType + "information"
+			}
+
+			prop, err := client.CreateProperty(api.ObjectType(objectType), req)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Property %s created for %s", prop.Name, objectType)
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"Name", prop.Name},
+				{"Label", prop.Label},
+				{"Type", prop.Type},
+				{"Field Type", prop.FieldType},
+				{"Group", prop.GroupName},
+			}
+
+			return v.Render(headers, rows, prop)
+		},
+	}
+
+	cmd.Flags().StringVar(&objectType, "object-type", "", "Object type (contacts, companies, deals, tickets, etc.)")
+	cmd.Flags().StringVar(&name, "name", "", "Property name (internal identifier)")
+	cmd.Flags().StringVar(&label, "label", "", "Property label (display name)")
+	cmd.Flags().StringVar(&propType, "type", "", "Property type (string, number, date, datetime, enumeration, bool)")
+	cmd.Flags().StringVar(&fieldType, "field-type", "", "Field type (text, textarea, number, date, select, checkbox, etc.)")
+	cmd.Flags().StringVar(&groupName, "group", "", "Property group name")
+	cmd.Flags().StringVar(&description, "description", "", "Property description")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var objectType, name string
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a property",
+		Long:  "Archive (soft delete) a custom property.",
+		Example: `  # Delete a custom property
+  hspt properties delete --object-type contacts --name my_field --force`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if objectType == "" || name == "" {
+				return fmt.Errorf("--object-type and --name are required")
+			}
+
+			if !force {
+				v.Warning("This will archive property %s for %s. Use --force to confirm.", name, objectType)
+				return nil
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteProperty(api.ObjectType(objectType), name); err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Property %s not found for %s", name, objectType)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Property %s archived for %s", name, objectType)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&objectType, "object-type", "", "Object type (contacts, companies, deals, tickets, etc.)")
+	cmd.Flags().StringVar(&name, "name", "", "Property name")
+	cmd.Flags().BoolVar(&force, "force", false, "Confirm deletion without prompt")
+
+	return cmd
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}


### PR DESCRIPTION
## Summary
- Add `hspt associations` commands (list, create, delete) using CRM v4 associations API
- Add `hspt properties` commands (list, get, create, delete) using CRM v3 properties API
- Add `hspt pipelines` commands (list, get, stages) using CRM v3 pipelines API

New API clients added:
- `api/associations.go` - Association management between CRM objects
- `api/properties.go` - Property schema management
- `api/pipelines.go` - Pipeline and stage management
- Added `put()` method to `api/client.go` for v4 association API

## Test plan
- [x] Build passes (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [ ] Manual verification with HubSpot API

Closes #20