### PR TITLE
feat: add Conversations channels and messages commands

### DIFF
--- a/api/conversations.go
+++ b/api/conversations.go
@@ -138,3 +138,159 @@ func (c *Client) GetThread(threadID string) (*Thread, error) {
 
 	return &result, nil
 }
+
+// Channel represents a HubSpot conversations channel
+type Channel struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	AccountID string `json:"accountId,omitempty"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+// ChannelList represents a paginated list of channels
+type ChannelList struct {
+	Results []Channel `json:"results"`
+	Paging  *Paging   `json:"paging,omitempty"`
+}
+
+// Message represents a HubSpot conversations message
+type Message struct {
+	ID          string                 `json:"id"`
+	Type        string                 `json:"type"`
+	Text        string                 `json:"text,omitempty"`
+	RichText    string                 `json:"richText,omitempty"`
+	Direction   string                 `json:"direction,omitempty"`
+	Status      string                 `json:"status,omitempty"`
+	ChannelID   string                 `json:"channelId,omitempty"`
+	ChannelType string                 `json:"channelAccountId,omitempty"`
+	SenderID    string                 `json:"senderId,omitempty"`
+	Recipients  []MessageRecipient     `json:"recipients,omitempty"`
+	CreatedAt   string                 `json:"createdAt"`
+	Client      map[string]interface{} `json:"client,omitempty"`
+}
+
+// MessageRecipient represents a recipient of a message
+type MessageRecipient struct {
+	RecipientID string `json:"recipientId,omitempty"`
+}
+
+// MessageList represents a paginated list of messages
+type MessageList struct {
+	Results []Message `json:"results"`
+	Paging  *Paging   `json:"paging,omitempty"`
+}
+
+// SendMessageRequest represents a request to send a message
+type SendMessageRequest struct {
+	Type      string `json:"type"`
+	Text      string `json:"text,omitempty"`
+	RichText  string `json:"richText,omitempty"`
+	SenderID  string `json:"senderActorId,omitempty"`
+	ChannelID string `json:"channelId,omitempty"`
+}
+
+// ListChannels retrieves channels with pagination
+func (c *Client) ListChannels(opts ListOptions) (*ChannelList, error) {
+	url := fmt.Sprintf("%s/conversations/v3/conversations/channels", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result ChannelList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse channels response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetChannel retrieves a single channel by ID
+func (c *Client) GetChannel(channelID string) (*Channel, error) {
+	if channelID == "" {
+		return nil, fmt.Errorf("channel ID is required")
+	}
+
+	url := fmt.Sprintf("%s/conversations/v3/conversations/channels/%s", c.BaseURL, channelID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Channel
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse channel response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListMessages retrieves messages for a thread
+func (c *Client) ListMessages(threadID string, opts ListOptions) (*MessageList, error) {
+	if threadID == "" {
+		return nil, fmt.Errorf("thread ID is required")
+	}
+
+	url := fmt.Sprintf("%s/conversations/v3/conversations/threads/%s/messages", c.BaseURL, threadID)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result MessageList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse messages response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// SendMessage sends a message to a thread
+func (c *Client) SendMessage(threadID string, req SendMessageRequest) (*Message, error) {
+	if threadID == "" {
+		return nil, fmt.Errorf("thread ID is required")
+	}
+
+	url := fmt.Sprintf("%s/conversations/v3/conversations/threads/%s/messages", c.BaseURL, threadID)
+
+	body, err := c.post(url, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Message
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse message response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/internal/cmd/conversations/conversations.go
+++ b/internal/cmd/conversations/conversations.go
@@ -1,6 +1,8 @@
 package conversations
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/hubspot-cli/api"
@@ -12,11 +14,13 @@ func Register(parent *cobra.Command, opts *root.Options) {
 	cmd := &cobra.Command{
 		Use:   "conversations",
 		Short: "Manage HubSpot conversations",
-		Long:  "Commands for listing and viewing conversations inboxes and threads.",
+		Long:  "Commands for listing and viewing conversations inboxes, threads, channels, and messages.",
 	}
 
 	cmd.AddCommand(newInboxesCmd(opts))
 	cmd.AddCommand(newThreadsCmd(opts))
+	cmd.AddCommand(newChannelsCmd(opts))
+	cmd.AddCommand(newMessagesCmd(opts))
 
 	parent.AddCommand(cmd)
 }
@@ -259,4 +263,264 @@ func formatBool(b bool) string {
 		return "Yes"
 	}
 	return "No"
+}
+
+func newChannelsCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "channels",
+		Short: "Manage channels",
+		Long:  "Commands for listing and viewing conversation channels.",
+	}
+
+	cmd.AddCommand(newChannelsListCmd(opts))
+	cmd.AddCommand(newChannelsGetCmd(opts))
+
+	return cmd
+}
+
+func newChannelsListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List channels",
+		Long:  "List conversation channels from HubSpot.",
+		Example: `  # List channels
+  hspt conversations channels list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListChannels(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No channels found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "TYPE", "CREATED"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, channel := range result.Results {
+				rows = append(rows, []string{
+					channel.ID,
+					channel.Name,
+					channel.Type,
+					channel.CreatedAt,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of channels to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newChannelsGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a channel by ID",
+		Long:  "Retrieve a single channel by its ID.",
+		Example: `  # Get channel by ID
+  hspt conversations channels get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			channel, err := client.GetChannel(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Channel %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", channel.ID},
+				{"Name", channel.Name},
+				{"Type", channel.Type},
+				{"Account ID", channel.AccountID},
+				{"Created", channel.CreatedAt},
+				{"Updated", channel.UpdatedAt},
+			}
+
+			return v.Render(headers, rows, channel)
+		},
+	}
+}
+
+func newMessagesCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "messages",
+		Short: "Manage messages",
+		Long:  "Commands for listing and sending conversation messages.",
+	}
+
+	cmd.AddCommand(newMessagesListCmd(opts))
+	cmd.AddCommand(newMessagesSendCmd(opts))
+
+	return cmd
+}
+
+func newMessagesListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list <threadId>",
+		Short: "List messages in a thread",
+		Long:  "List messages for a conversation thread.",
+		Example: `  # List messages in a thread
+  hspt conversations messages list 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			threadID := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListMessages(threadID, api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Thread %s not found", threadID)
+					return nil
+				}
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No messages found")
+				return nil
+			}
+
+			headers := []string{"ID", "TYPE", "DIRECTION", "TEXT", "CREATED"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, msg := range result.Results {
+				text := msg.Text
+				if text == "" {
+					text = msg.RichText
+				}
+				rows = append(rows, []string{
+					msg.ID,
+					msg.Type,
+					msg.Direction,
+					truncate(text, 50),
+					msg.CreatedAt,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of messages to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newMessagesSendCmd(opts *root.Options) *cobra.Command {
+	var text, channelID, senderID string
+
+	cmd := &cobra.Command{
+		Use:   "send <threadId>",
+		Short: "Send a message to a thread",
+		Long:  "Send a message to a conversation thread.",
+		Example: `  # Send a message
+  hspt conversations messages send 12345 --text "Hello, how can I help?"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			threadID := args[0]
+
+			if text == "" {
+				return fmt.Errorf("--text is required")
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			req := api.SendMessageRequest{
+				Type: "MESSAGE",
+				Text: text,
+			}
+			if channelID != "" {
+				req.ChannelID = channelID
+			}
+			if senderID != "" {
+				req.SenderID = senderID
+			}
+
+			msg, err := client.SendMessage(threadID, req)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Thread %s not found", threadID)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Message sent with ID: %s", msg.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&text, "text", "", "Message text content")
+	cmd.Flags().StringVar(&channelID, "channel-id", "", "Channel ID (optional)")
+	cmd.Flags().StringVar(&senderID, "sender-id", "", "Sender actor ID (optional)")
+
+	return cmd
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
 }


### PR DESCRIPTION
## Summary
- Add `hspt conversations channels list` - List conversation channels
- Add `hspt conversations channels get` - Get channel details
- Add `hspt conversations messages list` - List messages in a thread
- Add `hspt conversations messages send` - Send a message to a thread

## API additions
- `ListChannels()` - GET /conversations/v3/conversations/channels
- `GetChannel()` - GET /conversations/v3/conversations/channels/{channelId}
- `ListMessages()` - GET /conversations/v3/conversations/threads/{threadId}/messages
- `SendMessage()` - POST /conversations/v3/conversations/threads/{threadId}/messages

## Test plan
- [x] Build passes (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [ ] Manual verification with HubSpot API

Closes #21