### PR TITLE
feat: add CMS pages and blog commands

### DIFF
--- a/api/blogs.go
+++ b/api/blogs.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// BlogPost represents a HubSpot blog post
+type BlogPost struct {
+	ID                   string                 `json:"id"`
+	Name                 string                 `json:"name"`
+	Slug                 string                 `json:"slug,omitempty"`
+	State                string                 `json:"state,omitempty"`
+	AuthorName           string                 `json:"authorName,omitempty"`
+	BlogAuthorID         string                 `json:"blogAuthorId,omitempty"`
+	ContentGroupID       string                 `json:"contentGroupId,omitempty"`
+	Domain               string                 `json:"domain,omitempty"`
+	HTMLTitle            string                 `json:"htmlTitle,omitempty"`
+	MetaDescription      string                 `json:"metaDescription,omitempty"`
+	PostBody             string                 `json:"postBody,omitempty"`
+	PostSummary          string                 `json:"postSummary,omitempty"`
+	FeaturedImage        string                 `json:"featuredImage,omitempty"`
+	FeaturedImageAltText string                 `json:"featuredImageAltText,omitempty"`
+	PublishDate          string                 `json:"publishDate,omitempty"`
+	CreatedAt            string                 `json:"created,omitempty"`
+	UpdatedAt            string                 `json:"updated,omitempty"`
+	Archived             bool                   `json:"archived,omitempty"`
+	ArchivedAt           string                 `json:"archivedAt,omitempty"`
+	CurrentState         string                 `json:"currentState,omitempty"`
+	TagIDs               []int64                `json:"tagIds,omitempty"`
+	LayoutSections       map[string]interface{} `json:"layoutSections,omitempty"`
+}
+
+// BlogPostList represents a paginated list of blog posts
+type BlogPostList struct {
+	Results []BlogPost `json:"results"`
+	Paging  *Paging    `json:"paging,omitempty"`
+	Total   int        `json:"total,omitempty"`
+}
+
+// BlogAuthor represents a HubSpot blog author
+type BlogAuthor struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	FullName    string `json:"fullName,omitempty"`
+	Email       string `json:"email,omitempty"`
+	Slug        string `json:"slug,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Bio         string `json:"bio,omitempty"`
+	Website     string `json:"website,omitempty"`
+	Twitter     string `json:"twitter,omitempty"`
+	Facebook    string `json:"facebook,omitempty"`
+	LinkedIn    string `json:"linkedin,omitempty"`
+	Avatar      string `json:"avatar,omitempty"`
+	CreatedAt   string `json:"created,omitempty"`
+	UpdatedAt   string `json:"updated,omitempty"`
+}
+
+// BlogAuthorList represents a paginated list of blog authors
+type BlogAuthorList struct {
+	Results []BlogAuthor `json:"results"`
+	Paging  *Paging      `json:"paging,omitempty"`
+	Total   int          `json:"total,omitempty"`
+}
+
+// BlogTag represents a HubSpot blog tag
+type BlogTag struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Slug      string `json:"slug,omitempty"`
+	Language  string `json:"language,omitempty"`
+	CreatedAt string `json:"created,omitempty"`
+	UpdatedAt string `json:"updated,omitempty"`
+}
+
+// BlogTagList represents a paginated list of blog tags
+type BlogTagList struct {
+	Results []BlogTag `json:"results"`
+	Paging  *Paging   `json:"paging,omitempty"`
+	Total   int       `json:"total,omitempty"`
+}
+
+// ListBlogPosts retrieves blog posts with pagination
+func (c *Client) ListBlogPosts(opts ListOptions) (*BlogPostList, error) {
+	url := fmt.Sprintf("%s/cms/v3/blogs/posts", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result BlogPostList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse blog posts response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetBlogPost retrieves a single blog post by ID
+func (c *Client) GetBlogPost(postID string) (*BlogPost, error) {
+	if postID == "" {
+		return nil, fmt.Errorf("post ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/blogs/posts/%s", c.BaseURL, postID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result BlogPost
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse blog post response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CreateBlogPost creates a new blog post
+func (c *Client) CreateBlogPost(post map[string]interface{}) (*BlogPost, error) {
+	url := fmt.Sprintf("%s/cms/v3/blogs/posts", c.BaseURL)
+
+	body, err := c.post(url, post)
+	if err != nil {
+		return nil, err
+	}
+
+	var result BlogPost
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse blog post response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// UpdateBlogPost updates an existing blog post
+func (c *Client) UpdateBlogPost(postID string, updates map[string]interface{}) (*BlogPost, error) {
+	if postID == "" {
+		return nil, fmt.Errorf("post ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/blogs/posts/%s", c.BaseURL, postID)
+
+	body, err := c.patch(url, updates)
+	if err != nil {
+		return nil, err
+	}
+
+	var result BlogPost
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse blog post response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteBlogPost archives a blog post
+func (c *Client) DeleteBlogPost(postID string) error {
+	if postID == "" {
+		return fmt.Errorf("post ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/blogs/posts/%s", c.BaseURL, postID)
+
+	_, err := c.delete(url)
+	return err
+}
+
+// ListBlogAuthors retrieves blog authors with pagination
+func (c *Client) ListBlogAuthors(opts ListOptions) (*BlogAuthorList, error) {
+	url := fmt.Sprintf("%s/cms/v3/blogs/authors", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result BlogAuthorList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse blog authors response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListBlogTags retrieves blog tags with pagination
+func (c *Client) ListBlogTags(opts ListOptions) (*BlogTagList, error) {
+	url := fmt.Sprintf("%s/cms/v3/blogs/tags", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result BlogTagList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse blog tags response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/api/blogs_test.go
+++ b/api/blogs_test.go
@@ -1,0 +1,309 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListBlogPosts(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/blogs/posts", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "10", r.URL.Query().Get("limit"))
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "post-123",
+						"name": "My First Post",
+						"slug": "my-first-post",
+						"state": "PUBLISHED",
+						"authorName": "John Doe",
+						"created": "2024-01-15T10:00:00Z",
+						"updated": "2024-01-16T12:00:00Z"
+					}
+				],
+				"paging": {
+					"next": {
+						"after": "abc123"
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListBlogPosts(ListOptions{Limit: 10})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "post-123", result.Results[0].ID)
+		assert.Equal(t, "My First Post", result.Results[0].Name)
+		assert.Equal(t, "abc123", result.Paging.Next.After)
+	})
+
+	t.Run("empty results", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListBlogPosts(ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, result.Results)
+	})
+}
+
+func TestClient_GetBlogPost(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/blogs/posts/post-123", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "post-123",
+				"name": "My First Post",
+				"slug": "my-first-post",
+				"state": "PUBLISHED",
+				"authorName": "John Doe",
+				"htmlTitle": "My First Blog Post",
+				"metaDescription": "A great post",
+				"postSummary": "This is a summary",
+				"created": "2024-01-15T10:00:00Z",
+				"updated": "2024-01-16T12:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		post, err := client.GetBlogPost("post-123")
+		require.NoError(t, err)
+		assert.Equal(t, "post-123", post.ID)
+		assert.Equal(t, "My First Post", post.Name)
+		assert.Equal(t, "John Doe", post.AuthorName)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Post not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		post, err := client.GetBlogPost("nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, post)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		post, err := client.GetBlogPost("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "post ID is required")
+		assert.Nil(t, post)
+	})
+}
+
+func TestClient_CreateBlogPost(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/blogs/posts", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{
+				"id": "post-456",
+				"name": "New Post",
+				"slug": "new-post",
+				"state": "DRAFT",
+				"created": "2024-01-20T10:00:00Z",
+				"updated": "2024-01-20T10:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		data := map[string]interface{}{
+			"name": "New Post",
+			"slug": "new-post",
+		}
+		post, err := client.CreateBlogPost(data)
+		require.NoError(t, err)
+		assert.Equal(t, "post-456", post.ID)
+		assert.Equal(t, "New Post", post.Name)
+	})
+}
+
+func TestClient_UpdateBlogPost(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/blogs/posts/post-123", r.URL.Path)
+			assert.Equal(t, http.MethodPatch, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "post-123",
+				"name": "Updated Post",
+				"slug": "updated-post",
+				"state": "DRAFT",
+				"created": "2024-01-15T10:00:00Z",
+				"updated": "2024-01-21T10:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		updates := map[string]interface{}{
+			"name": "Updated Post",
+		}
+		post, err := client.UpdateBlogPost("post-123", updates)
+		require.NoError(t, err)
+		assert.Equal(t, "post-123", post.ID)
+		assert.Equal(t, "Updated Post", post.Name)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		post, err := client.UpdateBlogPost("", map[string]interface{}{"name": "test"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "post ID is required")
+		assert.Nil(t, post)
+	})
+}
+
+func TestClient_DeleteBlogPost(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/blogs/posts/post-123", r.URL.Path)
+			assert.Equal(t, http.MethodDelete, r.Method)
+
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		err := client.DeleteBlogPost("post-123")
+		require.NoError(t, err)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		err := client.DeleteBlogPost("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "post ID is required")
+	})
+}
+
+func TestClient_ListBlogAuthors(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/blogs/authors", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "author-123",
+						"name": "johndoe",
+						"fullName": "John Doe",
+						"email": "john@example.com",
+						"displayName": "John D."
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListBlogAuthors(ListOptions{})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "author-123", result.Results[0].ID)
+		assert.Equal(t, "John Doe", result.Results[0].FullName)
+	})
+}
+
+func TestClient_ListBlogTags(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/blogs/tags", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "tag-123",
+						"name": "Technology",
+						"slug": "technology",
+						"language": "en"
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListBlogTags(ListOptions{})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "tag-123", result.Results[0].ID)
+		assert.Equal(t, "Technology", result.Results[0].Name)
+	})
+}

--- a/api/pages.go
+++ b/api/pages.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// PageType represents the type of CMS page
+type PageType string
+
+const (
+	PageTypeSite    PageType = "site-pages"
+	PageTypeLanding PageType = "landing-pages"
+)
+
+// Page represents a HubSpot CMS page
+type Page struct {
+	ID              string                 `json:"id"`
+	Name            string                 `json:"name"`
+	Slug            string                 `json:"slug,omitempty"`
+	State           string                 `json:"state,omitempty"`
+	AuthorName      string                 `json:"authorName,omitempty"`
+	Domain          string                 `json:"domain,omitempty"`
+	Subcategory     string                 `json:"subcategory,omitempty"`
+	HTMLTitle       string                 `json:"htmlTitle,omitempty"`
+	MetaDescription string                 `json:"metaDescription,omitempty"`
+	PublishDate     string                 `json:"publishDate,omitempty"`
+	CreatedAt       string                 `json:"created,omitempty"`
+	UpdatedAt       string                 `json:"updated,omitempty"`
+	Archived        bool                   `json:"archived,omitempty"`
+	ArchivedAt      string                 `json:"archivedAt,omitempty"`
+	CurrentState    string                 `json:"currentState,omitempty"`
+	LayoutSections  map[string]interface{} `json:"layoutSections,omitempty"`
+}
+
+// PageList represents a paginated list of pages
+type PageList struct {
+	Results []Page  `json:"results"`
+	Paging  *Paging `json:"paging,omitempty"`
+	Total   int     `json:"total,omitempty"`
+}
+
+// ListPages retrieves pages with pagination
+func (c *Client) ListPages(pageType PageType, opts ListOptions) (*PageList, error) {
+	url := fmt.Sprintf("%s/cms/v3/pages/%s", c.BaseURL, pageType)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result PageList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse pages response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetPage retrieves a single page by ID
+func (c *Client) GetPage(pageType PageType, pageID string) (*Page, error) {
+	if pageID == "" {
+		return nil, fmt.Errorf("page ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/pages/%s/%s", c.BaseURL, pageType, pageID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Page
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse page response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CreatePage creates a new page
+func (c *Client) CreatePage(pageType PageType, page map[string]interface{}) (*Page, error) {
+	url := fmt.Sprintf("%s/cms/v3/pages/%s", c.BaseURL, pageType)
+
+	body, err := c.post(url, page)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Page
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse page response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// UpdatePage updates an existing page
+func (c *Client) UpdatePage(pageType PageType, pageID string, updates map[string]interface{}) (*Page, error) {
+	if pageID == "" {
+		return nil, fmt.Errorf("page ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/pages/%s/%s", c.BaseURL, pageType, pageID)
+
+	body, err := c.patch(url, updates)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Page
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse page response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeletePage archives a page
+func (c *Client) DeletePage(pageType PageType, pageID string) error {
+	if pageID == "" {
+		return fmt.Errorf("page ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/pages/%s/%s", c.BaseURL, pageType, pageID)
+
+	_, err := c.delete(url)
+	return err
+}
+
+// ClonePage creates a copy of an existing page
+func (c *Client) ClonePage(pageType PageType, pageID string) (*Page, error) {
+	if pageID == "" {
+		return nil, fmt.Errorf("page ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/pages/%s/%s/clone", c.BaseURL, pageType, pageID)
+
+	body, err := c.post(url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Page
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse page response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/api/pages_test.go
+++ b/api/pages_test.go
@@ -1,0 +1,277 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListPages(t *testing.T) {
+	t.Run("success site pages", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/pages/site-pages", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "10", r.URL.Query().Get("limit"))
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "page-123",
+						"name": "About Us",
+						"slug": "about-us",
+						"state": "PUBLISHED",
+						"created": "2024-01-15T10:00:00Z",
+						"updated": "2024-01-16T12:00:00Z"
+					}
+				],
+				"paging": {
+					"next": {
+						"after": "abc123"
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListPages(PageTypeSite, ListOptions{Limit: 10})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "page-123", result.Results[0].ID)
+		assert.Equal(t, "About Us", result.Results[0].Name)
+		assert.Equal(t, "abc123", result.Paging.Next.After)
+	})
+
+	t.Run("success landing pages", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/pages/landing-pages", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListPages(PageTypeLanding, ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, result.Results)
+	})
+}
+
+func TestClient_GetPage(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/pages/site-pages/page-123", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "page-123",
+				"name": "About Us",
+				"slug": "about-us",
+				"state": "PUBLISHED",
+				"htmlTitle": "About Our Company",
+				"metaDescription": "Learn about us",
+				"created": "2024-01-15T10:00:00Z",
+				"updated": "2024-01-16T12:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		page, err := client.GetPage(PageTypeSite, "page-123")
+		require.NoError(t, err)
+		assert.Equal(t, "page-123", page.ID)
+		assert.Equal(t, "About Us", page.Name)
+		assert.Equal(t, "About Our Company", page.HTMLTitle)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Page not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		page, err := client.GetPage(PageTypeSite, "nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, page)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		page, err := client.GetPage(PageTypeSite, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "page ID is required")
+		assert.Nil(t, page)
+	})
+}
+
+func TestClient_CreatePage(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/pages/site-pages", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{
+				"id": "page-456",
+				"name": "New Page",
+				"slug": "new-page",
+				"state": "DRAFT",
+				"created": "2024-01-20T10:00:00Z",
+				"updated": "2024-01-20T10:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		data := map[string]interface{}{
+			"name": "New Page",
+			"slug": "new-page",
+		}
+		page, err := client.CreatePage(PageTypeSite, data)
+		require.NoError(t, err)
+		assert.Equal(t, "page-456", page.ID)
+		assert.Equal(t, "New Page", page.Name)
+	})
+}
+
+func TestClient_UpdatePage(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/pages/site-pages/page-123", r.URL.Path)
+			assert.Equal(t, http.MethodPatch, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "page-123",
+				"name": "Updated Page",
+				"slug": "updated-page",
+				"state": "DRAFT",
+				"created": "2024-01-15T10:00:00Z",
+				"updated": "2024-01-21T10:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		updates := map[string]interface{}{
+			"name": "Updated Page",
+		}
+		page, err := client.UpdatePage(PageTypeSite, "page-123", updates)
+		require.NoError(t, err)
+		assert.Equal(t, "page-123", page.ID)
+		assert.Equal(t, "Updated Page", page.Name)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		page, err := client.UpdatePage(PageTypeSite, "", map[string]interface{}{"name": "test"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "page ID is required")
+		assert.Nil(t, page)
+	})
+}
+
+func TestClient_DeletePage(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/pages/site-pages/page-123", r.URL.Path)
+			assert.Equal(t, http.MethodDelete, r.Method)
+
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		err := client.DeletePage(PageTypeSite, "page-123")
+		require.NoError(t, err)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		err := client.DeletePage(PageTypeSite, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "page ID is required")
+	})
+}
+
+func TestClient_ClonePage(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/pages/site-pages/page-123/clone", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{
+				"id": "page-789",
+				"name": "About Us (Copy)",
+				"slug": "about-us-copy",
+				"state": "DRAFT",
+				"created": "2024-01-21T10:00:00Z",
+				"updated": "2024-01-21T10:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		page, err := client.ClonePage(PageTypeSite, "page-123")
+		require.NoError(t, err)
+		assert.Equal(t, "page-789", page.ID)
+		assert.Equal(t, "About Us (Copy)", page.Name)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		page, err := client.ClonePage(PageTypeSite, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "page ID is required")
+		assert.Nil(t, page)
+	})
+}

--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/associations"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/blogs"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/calls"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/campaigns"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/companies"
@@ -24,6 +25,7 @@ import (
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/meetings"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/notes"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/owners"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/pages"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/pipelines"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/products"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/properties"
@@ -80,6 +82,8 @@ func run() error {
 	// CMS commands
 	files.Register(rootCmd, opts)
 	domains.Register(rootCmd, opts)
+	pages.Register(rootCmd, opts)
+	blogs.Register(rootCmd, opts)
 
 	// Conversations commands
 	conversations.Register(rootCmd, opts)

--- a/internal/cmd/blogs/blogs.go
+++ b/internal/cmd/blogs/blogs.go
@@ -1,0 +1,451 @@
+package blogs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the blogs command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "blogs",
+		Short: "Manage HubSpot blog content",
+		Long:  "Commands for managing blog posts, authors, and tags.",
+	}
+
+	cmd.AddCommand(newPostsCmd(opts))
+	cmd.AddCommand(newAuthorsCmd(opts))
+	cmd.AddCommand(newTagsCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newPostsCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "posts",
+		Short: "Manage blog posts",
+		Long:  "Commands for listing, viewing, creating, updating, and deleting blog posts.",
+	}
+
+	cmd.AddCommand(newPostsListCmd(opts))
+	cmd.AddCommand(newPostsGetCmd(opts))
+	cmd.AddCommand(newPostsCreateCmd(opts))
+	cmd.AddCommand(newPostsUpdateCmd(opts))
+	cmd.AddCommand(newPostsDeleteCmd(opts))
+
+	return cmd
+}
+
+func newPostsListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List blog posts",
+		Long:  "List blog posts from HubSpot CMS.",
+		Example: `  # List blog posts
+  hspt blogs posts list
+
+  # List with pagination
+  hspt blogs posts list --limit 20`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListBlogPosts(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No blog posts found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "SLUG", "STATE", "AUTHOR"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, post := range result.Results {
+				rows = append(rows, []string{
+					post.ID,
+					truncate(post.Name, 30),
+					truncate(post.Slug, 25),
+					post.State,
+					post.AuthorName,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of posts to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newPostsGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a blog post by ID",
+		Long:  "Retrieve a single blog post by its ID.",
+		Example: `  # Get blog post by ID
+  hspt blogs posts get 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			post, err := client.GetBlogPost(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Blog post %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", post.ID},
+				{"Name", post.Name},
+				{"Slug", post.Slug},
+				{"State", post.State},
+				{"HTML Title", post.HTMLTitle},
+				{"Meta Description", truncate(post.MetaDescription, 50)},
+				{"Summary", truncate(post.PostSummary, 50)},
+				{"Author", post.AuthorName},
+				{"Author ID", post.BlogAuthorID},
+				{"Featured Image", truncate(post.FeaturedImage, 40)},
+				{"Archived", formatBool(post.Archived)},
+				{"Created", post.CreatedAt},
+				{"Updated", post.UpdatedAt},
+			}
+
+			if post.PublishDate != "" {
+				rows = append(rows, []string{"Published", post.PublishDate})
+			}
+
+			return v.Render(headers, rows, post)
+		},
+	}
+}
+
+func newPostsCreateCmd(opts *root.Options) *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new blog post",
+		Long:  "Create a new blog post in HubSpot CMS.",
+		Example: `  # Create a blog post from JSON file
+  hspt blogs posts create --file post.json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if file == "" {
+				return fmt.Errorf("--file is required")
+			}
+
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+
+			var postData map[string]interface{}
+			if err := json.Unmarshal(data, &postData); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			post, err := client.CreateBlogPost(postData)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Blog post created with ID: %s", post.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "JSON file containing post data (required)")
+
+	return cmd
+}
+
+func newPostsUpdateCmd(opts *root.Options) *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a blog post",
+		Long:  "Update an existing blog post in HubSpot CMS.",
+		Example: `  # Update a blog post from JSON file
+  hspt blogs posts update 12345 --file updates.json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if file == "" {
+				return fmt.Errorf("--file is required")
+			}
+
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+
+			var updates map[string]interface{}
+			if err := json.Unmarshal(data, &updates); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			post, err := client.UpdateBlogPost(id, updates)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Blog post %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Blog post %s updated", post.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "JSON file containing post updates (required)")
+
+	return cmd
+}
+
+func newPostsDeleteCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a blog post",
+		Long:  "Archive/delete a blog post in HubSpot CMS.",
+		Example: `  # Delete a blog post
+  hspt blogs posts delete 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			err = client.DeleteBlogPost(id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Blog post %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Blog post %s deleted", id)
+			return nil
+		},
+	}
+}
+
+func newAuthorsCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "authors",
+		Short: "Manage blog authors",
+		Long:  "Commands for listing blog authors.",
+	}
+
+	cmd.AddCommand(newAuthorsListCmd(opts))
+
+	return cmd
+}
+
+func newAuthorsListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List blog authors",
+		Long:  "List blog authors from HubSpot CMS.",
+		Example: `  # List blog authors
+  hspt blogs authors list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListBlogAuthors(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No blog authors found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "EMAIL", "DISPLAY NAME"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, author := range result.Results {
+				displayName := author.DisplayName
+				if displayName == "" {
+					displayName = author.FullName
+				}
+				rows = append(rows, []string{
+					author.ID,
+					author.Name,
+					author.Email,
+					displayName,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of authors to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newTagsCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tags",
+		Short: "Manage blog tags",
+		Long:  "Commands for listing blog tags.",
+	}
+
+	cmd.AddCommand(newTagsListCmd(opts))
+
+	return cmd
+}
+
+func newTagsListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List blog tags",
+		Long:  "List blog tags from HubSpot CMS.",
+		Example: `  # List blog tags
+  hspt blogs tags list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListBlogTags(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No blog tags found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "SLUG", "LANGUAGE"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, tag := range result.Results {
+				rows = append(rows, []string{
+					tag.ID,
+					tag.Name,
+					tag.Slug,
+					tag.Language,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of tags to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}

--- a/internal/cmd/pages/pages.go
+++ b/internal/cmd/pages/pages.go
@@ -1,0 +1,375 @@
+package pages
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the pages command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "pages",
+		Short: "Manage HubSpot CMS pages",
+		Long:  "Commands for listing, viewing, creating, updating, and deleting site and landing pages.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+	cmd.AddCommand(newCloneCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func parsePageType(typeStr string) api.PageType {
+	if typeStr == "landing" {
+		return api.PageTypeLanding
+	}
+	return api.PageTypeSite
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+	var pageType string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List pages",
+		Long:  "List site or landing pages from HubSpot CMS.",
+		Example: `  # List site pages
+  hspt pages list
+
+  # List landing pages
+  hspt pages list --type landing
+
+  # List with pagination
+  hspt pages list --limit 20`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			pt := parsePageType(pageType)
+			result, err := client.ListPages(pt, api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No pages found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "SLUG", "STATE", "UPDATED"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, page := range result.Results {
+				rows = append(rows, []string{
+					page.ID,
+					truncate(page.Name, 30),
+					truncate(page.Slug, 25),
+					page.State,
+					page.UpdatedAt,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of pages to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+	cmd.Flags().StringVar(&pageType, "type", "site", "Page type: site or landing")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var pageType string
+
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a page by ID",
+		Long:  "Retrieve a single page by its ID.",
+		Example: `  # Get site page by ID
+  hspt pages get 12345
+
+  # Get landing page by ID
+  hspt pages get 12345 --type landing`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			pt := parsePageType(pageType)
+			page, err := client.GetPage(pt, id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Page %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", page.ID},
+				{"Name", page.Name},
+				{"Slug", page.Slug},
+				{"State", page.State},
+				{"HTML Title", page.HTMLTitle},
+				{"Meta Description", truncate(page.MetaDescription, 50)},
+				{"Domain", page.Domain},
+				{"Author", page.AuthorName},
+				{"Archived", formatBool(page.Archived)},
+				{"Created", page.CreatedAt},
+				{"Updated", page.UpdatedAt},
+			}
+
+			if page.PublishDate != "" {
+				rows = append(rows, []string{"Published", page.PublishDate})
+			}
+
+			return v.Render(headers, rows, page)
+		},
+	}
+
+	cmd.Flags().StringVar(&pageType, "type", "site", "Page type: site or landing")
+
+	return cmd
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var file string
+	var pageType string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new page",
+		Long:  "Create a new site or landing page in HubSpot CMS.",
+		Example: `  # Create a site page from JSON file
+  hspt pages create --file page.json
+
+  # Create a landing page from JSON file
+  hspt pages create --file page.json --type landing`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if file == "" {
+				return fmt.Errorf("--file is required")
+			}
+
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+
+			var pageData map[string]interface{}
+			if err := json.Unmarshal(data, &pageData); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			pt := parsePageType(pageType)
+			page, err := client.CreatePage(pt, pageData)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Page created with ID: %s", page.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "JSON file containing page data (required)")
+	cmd.Flags().StringVar(&pageType, "type", "site", "Page type: site or landing")
+
+	return cmd
+}
+
+func newUpdateCmd(opts *root.Options) *cobra.Command {
+	var file string
+	var pageType string
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a page",
+		Long:  "Update an existing page in HubSpot CMS.",
+		Example: `  # Update a site page from JSON file
+  hspt pages update 12345 --file updates.json
+
+  # Update a landing page
+  hspt pages update 12345 --file updates.json --type landing`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			if file == "" {
+				return fmt.Errorf("--file is required")
+			}
+
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+
+			var updates map[string]interface{}
+			if err := json.Unmarshal(data, &updates); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			pt := parsePageType(pageType)
+			page, err := client.UpdatePage(pt, id, updates)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Page %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Page %s updated", page.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "JSON file containing page updates (required)")
+	cmd.Flags().StringVar(&pageType, "type", "site", "Page type: site or landing")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	var pageType string
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a page",
+		Long:  "Archive/delete a page in HubSpot CMS.",
+		Example: `  # Delete a site page
+  hspt pages delete 12345
+
+  # Delete a landing page
+  hspt pages delete 12345 --type landing`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			pt := parsePageType(pageType)
+			err = client.DeletePage(pt, id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Page %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Page %s deleted", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&pageType, "type", "site", "Page type: site or landing")
+
+	return cmd
+}
+
+func newCloneCmd(opts *root.Options) *cobra.Command {
+	var pageType string
+
+	cmd := &cobra.Command{
+		Use:   "clone <id>",
+		Short: "Clone a page",
+		Long:  "Create a copy of an existing page in HubSpot CMS.",
+		Example: `  # Clone a site page
+  hspt pages clone 12345
+
+  # Clone a landing page
+  hspt pages clone 12345 --type landing`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			id := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			pt := parsePageType(pageType)
+			page, err := client.ClonePage(pt, id)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Page %s not found", id)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Page cloned with new ID: %s", page.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&pageType, "type", "site", "Page type: site or landing")
+
+	return cmd
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}


### PR DESCRIPTION
## Summary
- Adds CLI commands for managing HubSpot CMS pages (site and landing pages)
- Adds CLI commands for managing blog posts, authors, and tags
- Includes comprehensive API tests for all new methods

## Commands Added

### Pages
- `hspt pages list [--type site|landing]` - List pages
- `hspt pages get <id> [--type site|landing]` - Get a page
- `hspt pages create --file page.json [--type site|landing]` - Create a page
- `hspt pages update <id> --file updates.json [--type site|landing]` - Update a page
- `hspt pages delete <id> [--type site|landing]` - Delete a page
- `hspt pages clone <id> [--type site|landing]` - Clone a page

### Blogs
- `hspt blogs posts list` - List blog posts
- `hspt blogs posts get <id>` - Get a blog post
- `hspt blogs posts create --file post.json` - Create a blog post
- `hspt blogs posts update <id> --file updates.json` - Update a blog post
- `hspt blogs posts delete <id>` - Delete a blog post
- `hspt blogs authors list` - List blog authors
- `hspt blogs tags list` - List blog tags

## Test plan
- [ ] `hspt pages list` lists site pages
- [ ] `hspt pages list --type landing` lists landing pages
- [ ] `hspt blogs posts list` lists blog posts
- [ ] `hspt blogs authors list` lists blog authors
- [ ] `hspt blogs tags list` lists blog tags

Closes #23