### PR TITLE
feat: add HubDB commands

### DIFF
--- a/api/hubdb.go
+++ b/api/hubdb.go
@@ -1,0 +1,284 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// HubDBTable represents a HubDB table
+type HubDBTable struct {
+	ID                    string                 `json:"id"`
+	Name                  string                 `json:"name"`
+	Label                 string                 `json:"label,omitempty"`
+	Published             bool                   `json:"published,omitempty"`
+	RowCount              int                    `json:"rowCount,omitempty"`
+	CreatedAt             string                 `json:"createdAt,omitempty"`
+	UpdatedAt             string                 `json:"updatedAt,omitempty"`
+	PublishedAt           string                 `json:"publishedAt,omitempty"`
+	Columns               []HubDBColumn          `json:"columns,omitempty"`
+	AllowPublicAPIAccess  bool                   `json:"allowPublicApiAccess,omitempty"`
+	AllowChildTables      bool                   `json:"allowChildTables,omitempty"`
+	EnableChildTablePages bool                   `json:"enableChildTablePages,omitempty"`
+	DynamicMetaTags       map[string]interface{} `json:"dynamicMetaTags,omitempty"`
+}
+
+// HubDBColumn represents a column in a HubDB table
+type HubDBColumn struct {
+	ID          string        `json:"id,omitempty"`
+	Name        string        `json:"name"`
+	Label       string        `json:"label,omitempty"`
+	Type        string        `json:"type"`
+	Description string        `json:"description,omitempty"`
+	Archived    bool          `json:"archived,omitempty"`
+	Options     []HubDBOption `json:"options,omitempty"`
+}
+
+// HubDBOption represents an option for select/multiselect columns
+type HubDBOption struct {
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name"`
+	Label string `json:"label,omitempty"`
+	Order int    `json:"order,omitempty"`
+}
+
+// HubDBTableList represents a paginated list of HubDB tables
+type HubDBTableList struct {
+	Results []HubDBTable `json:"results"`
+	Paging  *Paging      `json:"paging,omitempty"`
+	Total   int          `json:"total,omitempty"`
+}
+
+// HubDBRow represents a row in a HubDB table
+type HubDBRow struct {
+	ID        string                 `json:"id"`
+	Path      string                 `json:"path,omitempty"`
+	Name      string                 `json:"name,omitempty"`
+	CreatedAt string                 `json:"createdAt,omitempty"`
+	UpdatedAt string                 `json:"updatedAt,omitempty"`
+	Values    map[string]interface{} `json:"values,omitempty"`
+}
+
+// HubDBRowList represents a paginated list of HubDB rows
+type HubDBRowList struct {
+	Results []HubDBRow `json:"results"`
+	Paging  *Paging    `json:"paging,omitempty"`
+	Total   int        `json:"total,omitempty"`
+}
+
+// ListHubDBTables retrieves HubDB tables with pagination
+func (c *Client) ListHubDBTables(opts ListOptions) (*HubDBTableList, error) {
+	url := fmt.Sprintf("%s/cms/v3/hubdb/tables", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result HubDBTableList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse hubdb tables response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetHubDBTable retrieves a single HubDB table by ID or name
+func (c *Client) GetHubDBTable(tableIDOrName string) (*HubDBTable, error) {
+	if tableIDOrName == "" {
+		return nil, fmt.Errorf("table ID or name is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/hubdb/tables/%s", c.BaseURL, tableIDOrName)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result HubDBTable
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse hubdb table response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CreateHubDBTable creates a new HubDB table
+func (c *Client) CreateHubDBTable(table map[string]interface{}) (*HubDBTable, error) {
+	url := fmt.Sprintf("%s/cms/v3/hubdb/tables", c.BaseURL)
+
+	body, err := c.post(url, table)
+	if err != nil {
+		return nil, err
+	}
+
+	var result HubDBTable
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse hubdb table response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteHubDBTable deletes a HubDB table
+func (c *Client) DeleteHubDBTable(tableIDOrName string) error {
+	if tableIDOrName == "" {
+		return fmt.Errorf("table ID or name is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/hubdb/tables/%s", c.BaseURL, tableIDOrName)
+
+	_, err := c.delete(url)
+	return err
+}
+
+// PublishHubDBTable publishes a HubDB table draft
+func (c *Client) PublishHubDBTable(tableIDOrName string) (*HubDBTable, error) {
+	if tableIDOrName == "" {
+		return nil, fmt.Errorf("table ID or name is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/hubdb/tables/%s/draft/publish", c.BaseURL, tableIDOrName)
+
+	body, err := c.post(url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result HubDBTable
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse hubdb table response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListHubDBRows retrieves rows from a HubDB table
+func (c *Client) ListHubDBRows(tableIDOrName string, opts ListOptions) (*HubDBRowList, error) {
+	if tableIDOrName == "" {
+		return nil, fmt.Errorf("table ID or name is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/hubdb/tables/%s/rows", c.BaseURL, tableIDOrName)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result HubDBRowList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse hubdb rows response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetHubDBRow retrieves a single row from a HubDB table
+func (c *Client) GetHubDBRow(tableIDOrName, rowID string) (*HubDBRow, error) {
+	if tableIDOrName == "" {
+		return nil, fmt.Errorf("table ID or name is required")
+	}
+	if rowID == "" {
+		return nil, fmt.Errorf("row ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/hubdb/tables/%s/rows/%s", c.BaseURL, tableIDOrName, rowID)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result HubDBRow
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse hubdb row response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CreateHubDBRow creates a new row in a HubDB table draft
+func (c *Client) CreateHubDBRow(tableIDOrName string, row map[string]interface{}) (*HubDBRow, error) {
+	if tableIDOrName == "" {
+		return nil, fmt.Errorf("table ID or name is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/hubdb/tables/%s/rows/draft", c.BaseURL, tableIDOrName)
+
+	body, err := c.post(url, row)
+	if err != nil {
+		return nil, err
+	}
+
+	var result HubDBRow
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse hubdb row response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// UpdateHubDBRow updates a row in a HubDB table draft
+func (c *Client) UpdateHubDBRow(tableIDOrName, rowID string, updates map[string]interface{}) (*HubDBRow, error) {
+	if tableIDOrName == "" {
+		return nil, fmt.Errorf("table ID or name is required")
+	}
+	if rowID == "" {
+		return nil, fmt.Errorf("row ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/hubdb/tables/%s/rows/draft/%s", c.BaseURL, tableIDOrName, rowID)
+
+	body, err := c.patch(url, updates)
+	if err != nil {
+		return nil, err
+	}
+
+	var result HubDBRow
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse hubdb row response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteHubDBRow deletes a row from a HubDB table draft
+func (c *Client) DeleteHubDBRow(tableIDOrName, rowID string) error {
+	if tableIDOrName == "" {
+		return fmt.Errorf("table ID or name is required")
+	}
+	if rowID == "" {
+		return fmt.Errorf("row ID is required")
+	}
+
+	url := fmt.Sprintf("%s/cms/v3/hubdb/tables/%s/rows/draft/%s", c.BaseURL, tableIDOrName, rowID)
+
+	_, err := c.delete(url)
+	return err
+}

--- a/api/hubdb_test.go
+++ b/api/hubdb_test.go
@@ -1,0 +1,451 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListHubDBTables(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/hubdb/tables", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "10", r.URL.Query().Get("limit"))
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "123",
+						"name": "products",
+						"label": "Products Table",
+						"published": true,
+						"rowCount": 50,
+						"createdAt": "2024-01-15T10:00:00Z",
+						"updatedAt": "2024-01-16T12:00:00Z"
+					}
+				],
+				"paging": {
+					"next": {
+						"after": "abc123"
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListHubDBTables(ListOptions{Limit: 10})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "123", result.Results[0].ID)
+		assert.Equal(t, "products", result.Results[0].Name)
+		assert.Equal(t, 50, result.Results[0].RowCount)
+		assert.Equal(t, "abc123", result.Paging.Next.After)
+	})
+
+	t.Run("empty results", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListHubDBTables(ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, result.Results)
+	})
+}
+
+func TestClient_GetHubDBTable(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/hubdb/tables/products", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "123",
+				"name": "products",
+				"label": "Products Table",
+				"published": true,
+				"rowCount": 50,
+				"columns": [
+					{
+						"id": "1",
+						"name": "name",
+						"label": "Product Name",
+						"type": "TEXT"
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		table, err := client.GetHubDBTable("products")
+		require.NoError(t, err)
+		assert.Equal(t, "123", table.ID)
+		assert.Equal(t, "products", table.Name)
+		assert.Len(t, table.Columns, 1)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Table not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		table, err := client.GetHubDBTable("nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, table)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		table, err := client.GetHubDBTable("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "table ID or name is required")
+		assert.Nil(t, table)
+	})
+}
+
+func TestClient_CreateHubDBTable(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/hubdb/tables", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{
+				"id": "456",
+				"name": "new_table",
+				"label": "New Table",
+				"published": false
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		data := map[string]interface{}{
+			"name":  "new_table",
+			"label": "New Table",
+		}
+		table, err := client.CreateHubDBTable(data)
+		require.NoError(t, err)
+		assert.Equal(t, "456", table.ID)
+		assert.Equal(t, "new_table", table.Name)
+	})
+}
+
+func TestClient_DeleteHubDBTable(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/hubdb/tables/products", r.URL.Path)
+			assert.Equal(t, http.MethodDelete, r.Method)
+
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		err := client.DeleteHubDBTable("products")
+		require.NoError(t, err)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		err := client.DeleteHubDBTable("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "table ID or name is required")
+	})
+}
+
+func TestClient_PublishHubDBTable(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/hubdb/tables/products/draft/publish", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "123",
+				"name": "products",
+				"published": true,
+				"publishedAt": "2024-01-20T10:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		table, err := client.PublishHubDBTable("products")
+		require.NoError(t, err)
+		assert.Equal(t, "123", table.ID)
+		assert.True(t, table.Published)
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		table, err := client.PublishHubDBTable("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "table ID or name is required")
+		assert.Nil(t, table)
+	})
+}
+
+func TestClient_ListHubDBRows(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/hubdb/tables/products/rows", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "row-1",
+						"path": "/products/widget",
+						"name": "Widget",
+						"values": {
+							"1": "Widget Name",
+							"2": 29.99
+						}
+					}
+				]
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListHubDBRows("products", ListOptions{})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "row-1", result.Results[0].ID)
+		assert.Equal(t, "Widget", result.Results[0].Name)
+	})
+
+	t.Run("empty table ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		result, err := client.ListHubDBRows("", ListOptions{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "table ID or name is required")
+		assert.Nil(t, result)
+	})
+}
+
+func TestClient_GetHubDBRow(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/hubdb/tables/products/rows/row-1", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "row-1",
+				"path": "/products/widget",
+				"name": "Widget",
+				"values": {
+					"1": "Widget Name",
+					"2": 29.99
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		row, err := client.GetHubDBRow("products", "row-1")
+		require.NoError(t, err)
+		assert.Equal(t, "row-1", row.ID)
+		assert.Equal(t, "Widget", row.Name)
+	})
+
+	t.Run("empty table ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		row, err := client.GetHubDBRow("", "row-1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "table ID or name is required")
+		assert.Nil(t, row)
+	})
+
+	t.Run("empty row ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		row, err := client.GetHubDBRow("products", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "row ID is required")
+		assert.Nil(t, row)
+	})
+}
+
+func TestClient_CreateHubDBRow(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/hubdb/tables/products/rows/draft", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{
+				"id": "row-2",
+				"path": "/products/gadget",
+				"name": "Gadget"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		data := map[string]interface{}{
+			"path": "/products/gadget",
+			"name": "Gadget",
+		}
+		row, err := client.CreateHubDBRow("products", data)
+		require.NoError(t, err)
+		assert.Equal(t, "row-2", row.ID)
+	})
+
+	t.Run("empty table ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		row, err := client.CreateHubDBRow("", map[string]interface{}{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "table ID or name is required")
+		assert.Nil(t, row)
+	})
+}
+
+func TestClient_UpdateHubDBRow(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/hubdb/tables/products/rows/draft/row-1", r.URL.Path)
+			assert.Equal(t, http.MethodPatch, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "row-1",
+				"path": "/products/updated-widget",
+				"name": "Updated Widget"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		updates := map[string]interface{}{
+			"name": "Updated Widget",
+		}
+		row, err := client.UpdateHubDBRow("products", "row-1", updates)
+		require.NoError(t, err)
+		assert.Equal(t, "row-1", row.ID)
+		assert.Equal(t, "Updated Widget", row.Name)
+	})
+
+	t.Run("empty table ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		row, err := client.UpdateHubDBRow("", "row-1", map[string]interface{}{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "table ID or name is required")
+		assert.Nil(t, row)
+	})
+
+	t.Run("empty row ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		row, err := client.UpdateHubDBRow("products", "", map[string]interface{}{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "row ID is required")
+		assert.Nil(t, row)
+	})
+}
+
+func TestClient_DeleteHubDBRow(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cms/v3/hubdb/tables/products/rows/draft/row-1", r.URL.Path)
+			assert.Equal(t, http.MethodDelete, r.Method)
+
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		err := client.DeleteHubDBRow("products", "row-1")
+		require.NoError(t, err)
+	})
+
+	t.Run("empty table ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		err := client.DeleteHubDBRow("", "row-1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "table ID or name is required")
+	})
+
+	t.Run("empty row ID", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		err := client.DeleteHubDBRow("products", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "row ID is required")
+	})
+}

--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/files"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/forms"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/graphql"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/hubdb"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/initcmd"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/lineitems"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/marketingemails"
@@ -84,6 +85,7 @@ func run() error {
 	domains.Register(rootCmd, opts)
 	pages.Register(rootCmd, opts)
 	blogs.Register(rootCmd, opts)
+	hubdb.Register(rootCmd, opts)
 
 	// Conversations commands
 	conversations.Register(rootCmd, opts)

--- a/internal/cmd/hubdb/hubdb.go
+++ b/internal/cmd/hubdb/hubdb.go
@@ -1,0 +1,564 @@
+package hubdb
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the hubdb command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "hubdb",
+		Short: "Manage HubDB tables and rows",
+		Long:  "Commands for managing HubDB tables and rows. HubDB uses a draft/publish workflow.",
+	}
+
+	cmd.AddCommand(newTablesCmd(opts))
+	cmd.AddCommand(newRowsCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newTablesCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tables",
+		Short: "Manage HubDB tables",
+		Long:  "Commands for listing, viewing, creating, publishing, and deleting HubDB tables.",
+	}
+
+	cmd.AddCommand(newTablesListCmd(opts))
+	cmd.AddCommand(newTablesGetCmd(opts))
+	cmd.AddCommand(newTablesCreateCmd(opts))
+	cmd.AddCommand(newTablesDeleteCmd(opts))
+	cmd.AddCommand(newTablesPublishCmd(opts))
+
+	return cmd
+}
+
+func newTablesListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List HubDB tables",
+		Long:  "List HubDB tables from HubSpot CMS.",
+		Example: `  # List HubDB tables
+  hspt hubdb tables list
+
+  # List with pagination
+  hspt hubdb tables list --limit 20`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListHubDBTables(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No HubDB tables found")
+				return nil
+			}
+
+			headers := []string{"ID", "NAME", "LABEL", "ROWS", "PUBLISHED"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, table := range result.Results {
+				rows = append(rows, []string{
+					table.ID,
+					table.Name,
+					table.Label,
+					fmt.Sprintf("%d", table.RowCount),
+					formatBool(table.Published),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of tables to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newTablesGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <tableIdOrName>",
+		Short: "Get a HubDB table",
+		Long:  "Retrieve a single HubDB table by ID or name.",
+		Example: `  # Get table by ID
+  hspt hubdb tables get 12345
+
+  # Get table by name
+  hspt hubdb tables get my_table`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			tableIDOrName := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			table, err := client.GetHubDBTable(tableIDOrName)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("HubDB table %s not found", tableIDOrName)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", table.ID},
+				{"Name", table.Name},
+				{"Label", table.Label},
+				{"Row Count", fmt.Sprintf("%d", table.RowCount)},
+				{"Published", formatBool(table.Published)},
+				{"Public API Access", formatBool(table.AllowPublicAPIAccess)},
+				{"Created", table.CreatedAt},
+				{"Updated", table.UpdatedAt},
+			}
+
+			if table.PublishedAt != "" {
+				rows = append(rows, []string{"Published At", table.PublishedAt})
+			}
+
+			if len(table.Columns) > 0 {
+				rows = append(rows, []string{"Columns", fmt.Sprintf("%d", len(table.Columns))})
+			}
+
+			return v.Render(headers, rows, table)
+		},
+	}
+}
+
+func newTablesCreateCmd(opts *root.Options) *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new HubDB table",
+		Long:  "Create a new HubDB table from a JSON file.",
+		Example: `  # Create a HubDB table from JSON file
+  hspt hubdb tables create --file table.json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if file == "" {
+				return fmt.Errorf("--file is required")
+			}
+
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+
+			var tableData map[string]interface{}
+			if err := json.Unmarshal(data, &tableData); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			table, err := client.CreateHubDBTable(tableData)
+			if err != nil {
+				return err
+			}
+
+			v.Success("HubDB table created with ID: %s (name: %s)", table.ID, table.Name)
+			v.Info("Note: Table is in draft mode. Use 'hspt hubdb tables publish %s' to publish.", table.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "JSON file containing table definition (required)")
+
+	return cmd
+}
+
+func newTablesDeleteCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <tableIdOrName>",
+		Short: "Delete a HubDB table",
+		Long:  "Delete a HubDB table by ID or name.",
+		Example: `  # Delete table by ID
+  hspt hubdb tables delete 12345
+
+  # Delete table by name
+  hspt hubdb tables delete my_table`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			tableIDOrName := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			err = client.DeleteHubDBTable(tableIDOrName)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("HubDB table %s not found", tableIDOrName)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("HubDB table %s deleted", tableIDOrName)
+			return nil
+		},
+	}
+}
+
+func newTablesPublishCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "publish <tableIdOrName>",
+		Short: "Publish a HubDB table",
+		Long:  "Publish a HubDB table draft to make changes live.",
+		Example: `  # Publish table by ID
+  hspt hubdb tables publish 12345
+
+  # Publish table by name
+  hspt hubdb tables publish my_table`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			tableIDOrName := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			table, err := client.PublishHubDBTable(tableIDOrName)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("HubDB table %s not found", tableIDOrName)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("HubDB table %s published", table.ID)
+			return nil
+		},
+	}
+}
+
+func newRowsCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rows",
+		Short: "Manage HubDB table rows",
+		Long:  "Commands for listing, viewing, creating, updating, and deleting HubDB table rows.",
+	}
+
+	cmd.AddCommand(newRowsListCmd(opts))
+	cmd.AddCommand(newRowsGetCmd(opts))
+	cmd.AddCommand(newRowsCreateCmd(opts))
+	cmd.AddCommand(newRowsUpdateCmd(opts))
+	cmd.AddCommand(newRowsDeleteCmd(opts))
+
+	return cmd
+}
+
+func newRowsListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list <tableIdOrName>",
+		Short: "List rows in a HubDB table",
+		Long:  "List rows from a HubDB table.",
+		Example: `  # List rows in a table
+  hspt hubdb rows list my_table
+
+  # List with pagination
+  hspt hubdb rows list my_table --limit 50`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			tableIDOrName := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListHubDBRows(tableIDOrName, api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("HubDB table %s not found", tableIDOrName)
+					return nil
+				}
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No rows found in table %s", tableIDOrName)
+				return nil
+			}
+
+			headers := []string{"ID", "PATH", "NAME", "UPDATED"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, row := range result.Results {
+				rows = append(rows, []string{
+					row.ID,
+					row.Path,
+					row.Name,
+					row.UpdatedAt,
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of rows to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newRowsGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <tableIdOrName> <rowId>",
+		Short: "Get a row from a HubDB table",
+		Long:  "Retrieve a single row from a HubDB table.",
+		Example: `  # Get row by ID
+  hspt hubdb rows get my_table 12345`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			tableIDOrName := args[0]
+			rowID := args[1]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			row, err := client.GetHubDBRow(tableIDOrName, rowID)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Row %s not found in table %s", rowID, tableIDOrName)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"ID", row.ID},
+				{"Path", row.Path},
+				{"Name", row.Name},
+				{"Created", row.CreatedAt},
+				{"Updated", row.UpdatedAt},
+			}
+
+			// Add row values
+			for key, val := range row.Values {
+				valStr := fmt.Sprintf("%v", val)
+				rows = append(rows, []string{key, truncate(valStr, 50)})
+			}
+
+			return v.Render(headers, rows, row)
+		},
+	}
+}
+
+func newRowsCreateCmd(opts *root.Options) *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "create <tableIdOrName>",
+		Short: "Create a row in a HubDB table",
+		Long:  "Create a new row in a HubDB table draft. Remember to publish the table to make changes live.",
+		Example: `  # Create a row from JSON file
+  hspt hubdb rows create my_table --file row.json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			tableIDOrName := args[0]
+
+			if file == "" {
+				return fmt.Errorf("--file is required")
+			}
+
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+
+			var rowData map[string]interface{}
+			if err := json.Unmarshal(data, &rowData); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			row, err := client.CreateHubDBRow(tableIDOrName, rowData)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("HubDB table %s not found", tableIDOrName)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Row created with ID: %s", row.ID)
+			v.Info("Note: Row is in draft mode. Use 'hspt hubdb tables publish %s' to publish.", tableIDOrName)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "JSON file containing row data (required)")
+
+	return cmd
+}
+
+func newRowsUpdateCmd(opts *root.Options) *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "update <tableIdOrName> <rowId>",
+		Short: "Update a row in a HubDB table",
+		Long:  "Update a row in a HubDB table draft. Remember to publish the table to make changes live.",
+		Example: `  # Update a row from JSON file
+  hspt hubdb rows update my_table 12345 --file updates.json`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			tableIDOrName := args[0]
+			rowID := args[1]
+
+			if file == "" {
+				return fmt.Errorf("--file is required")
+			}
+
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+
+			var updates map[string]interface{}
+			if err := json.Unmarshal(data, &updates); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			row, err := client.UpdateHubDBRow(tableIDOrName, rowID, updates)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Row %s not found in table %s", rowID, tableIDOrName)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Row %s updated", row.ID)
+			v.Info("Note: Changes are in draft mode. Use 'hspt hubdb tables publish %s' to publish.", tableIDOrName)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "JSON file containing row updates (required)")
+
+	return cmd
+}
+
+func newRowsDeleteCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <tableIdOrName> <rowId>",
+		Short: "Delete a row from a HubDB table",
+		Long:  "Delete a row from a HubDB table draft. Remember to publish the table to make changes live.",
+		Example: `  # Delete a row
+  hspt hubdb rows delete my_table 12345`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			tableIDOrName := args[0]
+			rowID := args[1]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			err = client.DeleteHubDBRow(tableIDOrName, rowID)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Row %s not found in table %s", rowID, tableIDOrName)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Row %s deleted from draft", rowID)
+			v.Info("Note: Deletion is in draft mode. Use 'hspt hubdb tables publish %s' to publish.", tableIDOrName)
+			return nil
+		},
+	}
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}


### PR DESCRIPTION
## Summary
- Adds CLI commands for managing HubDB tables and rows
- Implements draft/publish workflow for HubDB changes
- Includes comprehensive API tests for all new methods

## Commands Added

### Tables
- `hspt hubdb tables list` - List HubDB tables
- `hspt hubdb tables get <tableIdOrName>` - Get a table
- `hspt hubdb tables create --file table.json` - Create a table
- `hspt hubdb tables delete <tableIdOrName>` - Delete a table
- `hspt hubdb tables publish <tableIdOrName>` - Publish table draft

### Rows
- `hspt hubdb rows list <tableIdOrName>` - List rows
- `hspt hubdb rows get <tableIdOrName> <rowId>` - Get a row
- `hspt hubdb rows create <tableIdOrName> --file row.json` - Create row in draft
- `hspt hubdb rows update <tableIdOrName> <rowId> --file row.json` - Update row in draft
- `hspt hubdb rows delete <tableIdOrName> <rowId>` - Delete row from draft

## Notes
HubDB uses a draft/publish workflow. Row changes are made to drafts and require publishing the table with `hspt hubdb tables publish` to go live.

## Test plan
- [ ] `hspt hubdb tables list` lists tables
- [ ] `hspt hubdb tables get <id>` shows table details
- [ ] `hspt hubdb tables publish <id>` publishes a draft
- [ ] `hspt hubdb rows list <table>` lists rows
- [ ] `hspt hubdb rows get <table> <row>` shows row details

Closes #24