### PR TITLE
feat: add custom objects schema commands

### DIFF
--- a/api/schemas.go
+++ b/api/schemas.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Schema represents a HubSpot custom object schema
+type Schema struct {
+	ID                         string           `json:"id,omitempty"`
+	ObjectTypeID               string           `json:"objectTypeId,omitempty"`
+	Name                       string           `json:"name"`
+	FullyQualifiedName         string           `json:"fullyQualifiedName,omitempty"`
+	Labels                     SchemaLabels     `json:"labels,omitempty"`
+	PrimaryDisplayProperty     string           `json:"primaryDisplayProperty,omitempty"`
+	SecondaryDisplayProperties []string         `json:"secondaryDisplayProperties,omitempty"`
+	RequiredProperties         []string         `json:"requiredProperties,omitempty"`
+	SearchableProperties       []string         `json:"searchableProperties,omitempty"`
+	Properties                 []SchemaProperty `json:"properties,omitempty"`
+	AssociatedObjects          []string         `json:"associatedObjects,omitempty"`
+	Archived                   bool             `json:"archived,omitempty"`
+	CreatedAt                  string           `json:"createdAt,omitempty"`
+	UpdatedAt                  string           `json:"updatedAt,omitempty"`
+}
+
+// SchemaLabels represents the labels for a custom object schema
+type SchemaLabels struct {
+	Singular string `json:"singular,omitempty"`
+	Plural   string `json:"plural,omitempty"`
+}
+
+// SchemaProperty represents a property definition in a schema
+type SchemaProperty struct {
+	Name           string `json:"name"`
+	Label          string `json:"label,omitempty"`
+	Type           string `json:"type"`
+	FieldType      string `json:"fieldType,omitempty"`
+	Description    string `json:"description,omitempty"`
+	GroupName      string `json:"groupName,omitempty"`
+	HasUniqueValue bool   `json:"hasUniqueValue,omitempty"`
+}
+
+// SchemaList represents a paginated list of schemas
+type SchemaList struct {
+	Results []Schema `json:"results"`
+	Paging  *Paging  `json:"paging,omitempty"`
+}
+
+// ListSchemas retrieves custom object schemas with pagination
+func (c *Client) ListSchemas(opts ListOptions) (*SchemaList, error) {
+	url := fmt.Sprintf("%s/crm/v3/schemas", c.BaseURL)
+
+	params := make(map[string]string)
+	if opts.Limit > 0 {
+		params["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if opts.After != "" {
+		params["after"] = opts.After
+	}
+
+	if len(params) > 0 {
+		url = buildURL(url, params)
+	}
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result SchemaList
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse schemas response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetSchema retrieves a single custom object schema by fully qualified name
+func (c *Client) GetSchema(fullyQualifiedName string) (*Schema, error) {
+	if fullyQualifiedName == "" {
+		return nil, fmt.Errorf("fully qualified name is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v3/schemas/%s", c.BaseURL, fullyQualifiedName)
+
+	body, err := c.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Schema
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse schema response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CreateSchema creates a new custom object schema
+func (c *Client) CreateSchema(schema map[string]interface{}) (*Schema, error) {
+	url := fmt.Sprintf("%s/crm/v3/schemas", c.BaseURL)
+
+	body, err := c.post(url, schema)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Schema
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse schema response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// DeleteSchema deletes a custom object schema
+func (c *Client) DeleteSchema(fullyQualifiedName string) error {
+	if fullyQualifiedName == "" {
+		return fmt.Errorf("fully qualified name is required")
+	}
+
+	url := fmt.Sprintf("%s/crm/v3/schemas/%s", c.BaseURL, fullyQualifiedName)
+
+	_, err := c.delete(url)
+	return err
+}

--- a/api/schemas_test.go
+++ b/api/schemas_test.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListSchemas(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/crm/v3/schemas", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "10", r.URL.Query().Get("limit"))
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"results": [
+					{
+						"id": "123",
+						"name": "my_custom_object",
+						"fullyQualifiedName": "p_my_custom_object",
+						"labels": {
+							"singular": "My Object",
+							"plural": "My Objects"
+						},
+						"properties": [
+							{
+								"name": "name",
+								"label": "Name",
+								"type": "string"
+							}
+						],
+						"createdAt": "2024-01-15T10:00:00Z",
+						"updatedAt": "2024-01-16T12:00:00Z"
+					}
+				],
+				"paging": {
+					"next": {
+						"after": "abc123"
+					}
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListSchemas(ListOptions{Limit: 10})
+		require.NoError(t, err)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "123", result.Results[0].ID)
+		assert.Equal(t, "my_custom_object", result.Results[0].Name)
+		assert.Equal(t, "p_my_custom_object", result.Results[0].FullyQualifiedName)
+		assert.Equal(t, "My Object", result.Results[0].Labels.Singular)
+		assert.Equal(t, "abc123", result.Paging.Next.After)
+	})
+
+	t.Run("empty results", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		result, err := client.ListSchemas(ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, result.Results)
+	})
+}
+
+func TestClient_GetSchema(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/crm/v3/schemas/p_my_custom_object", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "123",
+				"name": "my_custom_object",
+				"fullyQualifiedName": "p_my_custom_object",
+				"objectTypeId": "2-123456",
+				"labels": {
+					"singular": "My Object",
+					"plural": "My Objects"
+				},
+				"primaryDisplayProperty": "name",
+				"properties": [
+					{
+						"name": "name",
+						"label": "Name",
+						"type": "string",
+						"fieldType": "text"
+					}
+				],
+				"associatedObjects": ["contacts", "companies"],
+				"createdAt": "2024-01-15T10:00:00Z",
+				"updatedAt": "2024-01-16T12:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		schema, err := client.GetSchema("p_my_custom_object")
+		require.NoError(t, err)
+		assert.Equal(t, "123", schema.ID)
+		assert.Equal(t, "my_custom_object", schema.Name)
+		assert.Equal(t, "2-123456", schema.ObjectTypeID)
+		assert.Len(t, schema.Properties, 1)
+		assert.Len(t, schema.AssociatedObjects, 2)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"status": "error", "message": "Schema not found"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		schema, err := client.GetSchema("p_nonexistent")
+		assert.Error(t, err)
+		assert.True(t, IsNotFound(err))
+		assert.Nil(t, schema)
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		schema, err := client.GetSchema("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "fully qualified name is required")
+		assert.Nil(t, schema)
+	})
+}
+
+func TestClient_CreateSchema(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/crm/v3/schemas", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{
+				"id": "456",
+				"name": "new_object",
+				"fullyQualifiedName": "p_new_object",
+				"labels": {
+					"singular": "New Object",
+					"plural": "New Objects"
+				},
+				"createdAt": "2024-01-20T10:00:00Z"
+			}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		data := map[string]interface{}{
+			"name": "new_object",
+			"labels": map[string]string{
+				"singular": "New Object",
+				"plural":   "New Objects",
+			},
+		}
+		schema, err := client.CreateSchema(data)
+		require.NoError(t, err)
+		assert.Equal(t, "456", schema.ID)
+		assert.Equal(t, "new_object", schema.Name)
+		assert.Equal(t, "p_new_object", schema.FullyQualifiedName)
+	})
+}
+
+func TestClient_DeleteSchema(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/crm/v3/schemas/p_my_custom_object", r.URL.Path)
+			assert.Equal(t, http.MethodDelete, r.Method)
+
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			BaseURL:     server.URL,
+			AccessToken: "test-token",
+			HTTPClient:  server.Client(),
+		}
+
+		err := client.DeleteSchema("p_my_custom_object")
+		require.NoError(t, err)
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		client := &Client{BaseURL: "https://api.hubapi.com"}
+		err := client.DeleteSchema("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "fully qualified name is required")
+	})
+}

--- a/cmd/hspt/main.go
+++ b/cmd/hspt/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/properties"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/quotes"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/schemas"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/tasks"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/tickets"
 	"github.com/open-cli-collective/hubspot-cli/internal/cmd/workflows"
@@ -74,6 +75,7 @@ func run() error {
 	associations.Register(rootCmd, opts)
 	properties.Register(rootCmd, opts)
 	pipelines.Register(rootCmd, opts)
+	schemas.Register(rootCmd, opts)
 
 	// Marketing commands
 	forms.Register(rootCmd, opts)

--- a/internal/cmd/schemas/schemas.go
+++ b/internal/cmd/schemas/schemas.go
@@ -1,0 +1,237 @@
+package schemas
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/hubspot-cli/api"
+	"github.com/open-cli-collective/hubspot-cli/internal/cmd/root"
+)
+
+// Register registers the schemas command and subcommands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "schemas",
+		Short: "Manage custom object schemas",
+		Long:  "Commands for listing, viewing, creating, and deleting custom object schemas. Requires Operations Hub Professional or Enterprise.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	var limit int
+	var after string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List custom object schemas",
+		Long:  "List all custom object schemas in your HubSpot account.",
+		Example: `  # List schemas
+  hspt schemas list
+
+  # List with pagination
+  hspt schemas list --limit 20`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			result, err := client.ListSchemas(api.ListOptions{
+				Limit: limit,
+				After: after,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(result.Results) == 0 {
+				v.Info("No custom object schemas found")
+				return nil
+			}
+
+			headers := []string{"NAME", "FULLY QUALIFIED NAME", "LABELS", "PROPERTIES"}
+			rows := make([][]string, 0, len(result.Results))
+			for _, schema := range result.Results {
+				labels := ""
+				if schema.Labels.Singular != "" {
+					labels = fmt.Sprintf("%s / %s", schema.Labels.Singular, schema.Labels.Plural)
+				}
+				rows = append(rows, []string{
+					schema.Name,
+					schema.FullyQualifiedName,
+					labels,
+					fmt.Sprintf("%d", len(schema.Properties)),
+				})
+			}
+
+			if err := v.Render(headers, rows, result); err != nil {
+				return err
+			}
+
+			if result.Paging != nil && result.Paging.Next != nil {
+				v.Info("\nMore results available. Use --after %s to get the next page.", result.Paging.Next.After)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of schemas to return")
+	cmd.Flags().StringVar(&after, "after", "", "Pagination cursor for the next page")
+
+	return cmd
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <fullyQualifiedName>",
+		Short: "Get a custom object schema",
+		Long:  "Retrieve a single custom object schema by its fully qualified name.",
+		Example: `  # Get schema by fully qualified name
+  hspt schemas get p_my_custom_object`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			fqn := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			schema, err := client.GetSchema(fqn)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Schema %s not found", fqn)
+					return nil
+				}
+				return err
+			}
+
+			headers := []string{"PROPERTY", "VALUE"}
+			rows := [][]string{
+				{"Name", schema.Name},
+				{"Fully Qualified Name", schema.FullyQualifiedName},
+				{"Object Type ID", schema.ObjectTypeID},
+				{"Singular Label", schema.Labels.Singular},
+				{"Plural Label", schema.Labels.Plural},
+				{"Primary Display Property", schema.PrimaryDisplayProperty},
+				{"Archived", formatBool(schema.Archived)},
+				{"Created", schema.CreatedAt},
+				{"Updated", schema.UpdatedAt},
+			}
+
+			if len(schema.Properties) > 0 {
+				propNames := make([]string, 0, len(schema.Properties))
+				for _, prop := range schema.Properties {
+					propNames = append(propNames, prop.Name)
+				}
+				rows = append(rows, []string{"Properties", strings.Join(propNames, ", ")})
+			}
+
+			if len(schema.AssociatedObjects) > 0 {
+				rows = append(rows, []string{"Associated Objects", strings.Join(schema.AssociatedObjects, ", ")})
+			}
+
+			return v.Render(headers, rows, schema)
+		},
+	}
+}
+
+func newCreateCmd(opts *root.Options) *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a custom object schema",
+		Long:  "Create a new custom object schema from a JSON file. Requires Operations Hub Professional or Enterprise.",
+		Example: `  # Create a schema from JSON file
+  hspt schemas create --file schema.json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+
+			if file == "" {
+				return fmt.Errorf("--file is required")
+			}
+
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+
+			var schemaData map[string]interface{}
+			if err := json.Unmarshal(data, &schemaData); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			schema, err := client.CreateSchema(schemaData)
+			if err != nil {
+				return err
+			}
+
+			v.Success("Schema created: %s (fully qualified name: %s)", schema.Name, schema.FullyQualifiedName)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "JSON file containing schema definition (required)")
+
+	return cmd
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <fullyQualifiedName>",
+		Short: "Delete a custom object schema",
+		Long:  "Delete a custom object schema by its fully qualified name. This will also delete all objects of that type.",
+		Example: `  # Delete schema by fully qualified name
+  hspt schemas delete p_my_custom_object`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := opts.View()
+			fqn := args[0]
+
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
+			}
+
+			err = client.DeleteSchema(fqn)
+			if err != nil {
+				if api.IsNotFound(err) {
+					v.Error("Schema %s not found", fqn)
+					return nil
+				}
+				return err
+			}
+
+			v.Success("Schema %s deleted", fqn)
+			return nil
+		},
+	}
+}
+
+func formatBool(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}


### PR DESCRIPTION
## Summary
Add CLI commands and API client for HubSpot custom object schemas (requires Operations Hub Professional or Enterprise).

### API Layer (`api/schemas.go`)
- `Schema`, `SchemaLabels`, `SchemaProperty` types
- `ListSchemas(opts)` - list all custom object schemas with pagination
- `GetSchema(fullyQualifiedName)` - get a single schema by FQN
- `CreateSchema(data)` - create a new schema from JSON
- `DeleteSchema(fullyQualifiedName)` - delete a schema by FQN

### CLI Commands
- `hspt schemas list` - list custom object schemas
- `hspt schemas get <fqn>` - get schema details
- `hspt schemas create --file schema.json` - create from JSON file
- `hspt schemas delete <fqn>` - delete a schema

### Tests
- Comprehensive API tests in `api/schemas_test.go`
- Tests cover success cases, empty results, not found errors, and validation

## Test Plan
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes
- [x] API tests cover all CRUD operations

Closes #25