### PR TITLE
fix(release): declare hspt as the Homebrew cask binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,6 +68,7 @@ homebrew_casks:
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     homepage: https://github.com/open-cli-collective/hubspot-cli
     description: "Command-line interface for HubSpot"
+    binary: hspt
     hooks:
       post:
         install: |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A command-line interface for HubSpot CRM. Manage contacts, companies, deals, and
 **Homebrew (recommended)**
 
 ```bash
-brew install open-cli-collective/tap/hspt
+brew install open-cli-collective/tap/hubspot-cli
 ```
 
 ---


### PR DESCRIPTION
## Summary

Closes #62. `brew install open-cli-collective/tap/hubspot-cli` fails at the link step: the generated cask declares `binary "hubspot-cli"`, but the release tarball ships `hspt` — there is no `hubspot-cli` file to link.

## Cause

The `homebrew_casks` entry in `.goreleaser.yml` omitted `binary`, so GoReleaser fell back to the **cask name** (`hubspot-cli`) instead of the built binary (`hspt`). (The postflight hook already used the correct `#{staged_path}/hspt`.)

## Fix

- Add `binary: hspt` to the cask — mirroring **salesforce-cli**, whose cask correctly sets `binary: sfdc`. On the next release the tap regenerates `Casks/hubspot-cli.rb` with `binary "hspt"`, so the link succeeds.
- Fix the README install command, which pointed at a nonexistent `hspt` cask/formula; the only tap artifact is the `hubspot-cli` cask.

## Notes

Cask name stays `hubspot-cli` (consistent with `salesforce-cli`). The bug clears once a release cuts and regenerates the tap — this merge triggers that via auto-release.