### PR TITLE
fix(release): release on packaging/config changes; add manual dispatch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -24,9 +24,11 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     # Release on feat:/fix: commits (semantic versioning), or on a manual
-    # dispatch (which carries no head_commit to inspect).
+    # dispatch. The dispatch arm is scoped to main so the manual lever can
+    # never tag/release arbitrary non-main content (the push arm is already
+    # branch-scoped, and the checkout below is unpinned).
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
       startsWith(github.event.head_commit.message, 'feat:') ||
       startsWith(github.event.head_commit.message, 'feat(') ||
       startsWith(github.event.head_commit.message, 'fix:') ||

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,6 +7,15 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      # Packaging/release config also affects the shipped artifact, so a fix
+      # to these must be releasable on its own (e.g. a Homebrew cask fix that
+      # touches no Go files). See #62.
+      - '.goreleaser.yml'
+      - 'version.txt'
+      - '.github/workflows/auto-release.yml'
+      - '.github/workflows/release.yml'
+  # Manual lever to cut a release for a change the path filter doesn't catch.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,8 +23,10 @@ permissions:
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    # Only release on feat: or fix: commits (semantic versioning)
+    # Release on feat:/fix: commits (semantic versioning), or on a manual
+    # dispatch (which carries no head_commit to inspect).
     if: >-
+      github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.head_commit.message, 'feat:') ||
       startsWith(github.event.head_commit.message, 'feat(') ||
       startsWith(github.event.head_commit.message, 'fix:') ||

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,14 +134,16 @@ docs(readme): add examples
 
 Releases are automated with a dual-gate system to avoid unnecessary releases:
 
-**Gate 1 - Path filter:** Only triggers when Go code changes (`**.go`, `go.mod`, `go.sum`)
-**Gate 2 - Commit prefix:** Only `feat:` and `fix:` commits create releases
+**Gate 1 - Path filter:** Triggers when Go code (`**.go`, `go.mod`, `go.sum`) **or** release-affecting config (`.goreleaser.yml`, `version.txt`, the `auto-release`/`release` workflow files) changes. Packaging config affects the shipped artifact, so a fix there must be releasable on its own (see #62).
+**Gate 2 - Commit prefix:** Only `feat:` and `fix:` commits create releases.
+
+**Manual lever:** the `Auto Release` workflow also accepts a `workflow_dispatch` (scoped to `main`) to cut a release on demand for a change the path filter can't catch. The commit-prefix gate does not apply to a manual dispatch.
 
 This means:
-- `feat: add command` + Go files changed → release
-- `fix: handle edge case` + Go files changed → release
-- `docs:`, `ci:`, `test:`, `refactor:` → no release
-- Changes only to docs, packaging, workflows → no release
+- `feat: add command` / `fix: handle edge case` + a watched path changed → release
+- A packaging/release-config fix (e.g. a Homebrew cask fix in `.goreleaser.yml`) → release, so it reaches the tap
+- `docs:`, `ci:`, `test:`, `refactor:`, or changes only to docs / non-release CI → no release
+- Actions → Auto Release → Run workflow (on `main`) → release
 
 **After merging a release-triggering PR:** The workflow creates a tag, which triggers GoReleaser to build binaries and publish to Homebrew. Chocolatey and Winget are published automatically.
 


### PR DESCRIPTION
## Summary

Follow-up to #63/#62. Auto Release only triggered on `**.go`/`go.mod`/`go.sum`, so a packaging fix touching no Go files (the #62 cask `binary` fix) never cut a release — the corrected cask never reached the tap.

## Changes

- Add `.goreleaser.yml`, `version.txt`, and the release workflow files to the `paths` trigger, so release-affecting config changes are releasable on their own.
- Add a `workflow_dispatch` lever (with the `if` gate updated to allow it, since a manual dispatch carries no `head_commit`) to cut a release on demand.

## Effect

Merging this squash-commit (`fix(...)`) itself modifies a now-watched path (`.github/workflows/auto-release.yml`), so it triggers Auto Release and ships the pending cask fix with a correctly-numbered `v0.1.<run>` release — no manual tag, no collision with the run-number scheme.